### PR TITLE
CLOUD-580: incorporate s3 bucket policy improvements

### DIFF
--- a/lib/s3.ts
+++ b/lib/s3.ts
@@ -2,7 +2,7 @@ import * as s3 from "@aws-cdk/aws-s3";
 import {BucketPolicy} from "@aws-cdk/aws-s3";
 import {AccessCapability, AccessSpec, K9PolicyFactory} from "./k9policy";
 import * as cdk from "@aws-cdk/core";
-import {AnyPrincipal, Effect, PolicyStatement} from "@aws-cdk/aws-iam";
+import {AccountRootPrincipal, AnyPrincipal, Effect, PolicyStatement} from "@aws-cdk/aws-iam";
 
 export interface K9BucketPolicyProps extends s3.BucketPolicyProps {
     readonly k9DesiredAccess: Array<AccessSpec>
@@ -85,7 +85,7 @@ export function makeBucketPolicy(scope: cdk.Construct, id: string, props: K9Buck
         new PolicyStatement({
             sid: 'DenyEveryoneElse',
             effect: Effect.DENY,
-            principals: [new AnyPrincipal()],
+            principals: [new AccountRootPrincipal()],
             actions: ['s3:*'],
             resources: resourceArns,
             conditions: {

--- a/lib/s3.ts
+++ b/lib/s3.ts
@@ -26,6 +26,7 @@ export function makeBucketPolicy(scope: cdk.Construct, id: string, props: K9Buck
     ];
 
     let allAllowedPrincipalArns = new Set<string>();
+    let wasArnLikeTestUsed = false;
 
     let accessSpecsByCapability: Map<AccessCapability, AccessSpec> = new Map<AccessCapability, AccessSpec>();
 
@@ -40,6 +41,10 @@ export function makeBucketPolicy(scope: cdk.Construct, id: string, props: K9Buck
             }
         ;
         let arnConditionTest = accessSpec.test || "ArnEquals";
+        if (arnConditionTest == "ArnLike"){
+            wasArnLikeTestUsed = true;
+        }
+
         let statement = policyFactory.makeAllowStatement(`Restricted-${supportedCapability}`,
             policyFactory.getActions('S3', supportedCapability),
             accessSpec.allowPrincipalArns,
@@ -52,7 +57,19 @@ export function makeBucketPolicy(scope: cdk.Construct, id: string, props: K9Buck
         });
     }
 
-    policy.document.addStatements(new PolicyStatement({
+    const denyEveryoneElseTest = wasArnLikeTestUsed ? 'ArnNotLike' : 'ArnNotEquals';
+    let denyEveryoneElseStatement = new PolicyStatement({
+                sid: 'DenyEveryoneElse',
+                effect: Effect.DENY,
+                principals: [new AccountRootPrincipal()],
+                actions: ['s3:*'],
+                resources: resourceArns
+            });
+    denyEveryoneElseStatement.addCondition(denyEveryoneElseTest,
+        {'aws:PrincipalArn': [...allAllowedPrincipalArns]});
+
+    policy.document.addStatements(
+        new PolicyStatement({
             sid: 'DenyInsecureCommunications',
             effect: Effect.DENY,
             principals: [new AnyPrincipal()],
@@ -82,16 +99,7 @@ export function makeBucketPolicy(scope: cdk.Construct, id: string, props: K9Buck
                 'StringNotEquals': {'s3:x-amz-server-side-encryption': 'aws:kms'},
             },
         }),
-        new PolicyStatement({
-            sid: 'DenyEveryoneElse',
-            effect: Effect.DENY,
-            principals: [new AccountRootPrincipal()],
-            actions: ['s3:*'],
-            resources: resourceArns,
-            conditions: {
-                ArnNotEquals: {'aws:PrincipalArn': [...allAllowedPrincipalArns]},
-            },
-        })
+        denyEveryoneElseStatement,
     );
 
     policy.document.validateForResourcePolicy();

--- a/test/__snapshots__/k9policy.test.ts.snap
+++ b/test/__snapshots__/k9policy.test.ts.snap
@@ -343,7 +343,24 @@ Object {
                 },
               },
               "Effect": "Deny",
-              "Principal": "*",
+              "Principal": Object {
+                "AWS": Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      "arn:",
+                      Object {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":iam::",
+                      Object {
+                        "Ref": "AWS::AccountId",
+                      },
+                      ":root",
+                    ],
+                  ],
+                },
+              },
               "Resource": Array [
                 Object {
                   "Fn::GetAtt": Array [


### PR DESCRIPTION
This release improves scoping of the access controls:

* The DenyEveryoneElse statement scopes its coverage to the account's IAM users instead of all IAM principals, enabling use provisioned by an AWS service via KMS key grants, e.g. DynamoDB
* Use Like within the Deny when an Allow statement has done so
