### PR TITLE
CLOUD-769: Scope Principals of DenyEveryoneElse Statement to all AWS accounts & IAM

### DIFF
--- a/lib/kms.ts
+++ b/lib/kms.ts
@@ -31,7 +31,7 @@ export function makeKeyPolicy(scope: cdk.Construct, id: string, props: K9KeyPoli
     const denyEveryoneElseStatement = new PolicyStatement({
         sid: 'DenyEveryoneElse',
         effect: Effect.DENY,
-        principals: [new AccountRootPrincipal()],
+        principals: policyFactory.makeDenyEveryoneElsePrincipals(),
         actions: ['kms:*'],
         resources: resourceArns
     });

--- a/lib/s3.ts
+++ b/lib/s3.ts
@@ -2,7 +2,7 @@ import * as s3 from "@aws-cdk/aws-s3";
 import {BucketPolicy} from "@aws-cdk/aws-s3";
 import {AccessCapability, AccessSpec, K9PolicyFactory} from "./k9policy";
 import * as cdk from "@aws-cdk/core";
-import {AccountRootPrincipal, AnyPrincipal, Effect, PolicyStatement} from "@aws-cdk/aws-iam";
+import {AnyPrincipal, Effect, PolicyStatement} from "@aws-cdk/aws-iam";
 
 export interface K9BucketPolicyProps extends s3.BucketPolicyProps {
     readonly k9DesiredAccess: Array<AccessSpec>
@@ -32,13 +32,28 @@ export function makeBucketPolicy(scope: cdk.Construct, id: string, props: K9Buck
         resourceArns);
     policy.document.addStatements(...allowStatements);
 
+
+    // denyEveryoneElsePrincipals requires explanation.
+    // We want to deny all AWS accounts and IAM principals not explicitly allowed.
+    // We (should) need AnyPrincipal once (of course), but provide multiple times so that
+    // AWS CDK does not convert:
+    // "Principal": {
+    //     "AWS": "*"    // identifies all AWS accounts and IAM.
+    // }
+    // to:
+    // "Principal": "*"  // identifies all principals including AWS Service principals
+    //
+    // S3 rewrites the AWS member of the policy on save so only the unique set of principals are included
+    // So after these machinations, we end up with what we want.
+    const denyEveryoneElsePrincipals = [new AnyPrincipal(), new AnyPrincipal()];
+
     const denyEveryoneElseTest = policyFactory.wasLikeUsed(props.k9DesiredAccess) ?
         'ArnNotLike' :
         'ArnNotEquals';
     const denyEveryoneElseStatement = new PolicyStatement({
                 sid: 'DenyEveryoneElse',
                 effect: Effect.DENY,
-                principals: [new AccountRootPrincipal()],
+                principals: denyEveryoneElsePrincipals,
                 actions: ['s3:*'],
                 resources: resourceArns
             });

--- a/lib/s3.ts
+++ b/lib/s3.ts
@@ -33,27 +33,13 @@ export function makeBucketPolicy(scope: cdk.Construct, id: string, props: K9Buck
     policy.document.addStatements(...allowStatements);
 
 
-    // denyEveryoneElsePrincipals requires explanation.
-    // We want to deny all AWS accounts and IAM principals not explicitly allowed.
-    // We (should) need AnyPrincipal once (of course), but provide multiple times so that
-    // AWS CDK does not convert:
-    // "Principal": {
-    //     "AWS": "*"    // identifies all AWS accounts and IAM.
-    // }
-    // to:
-    // "Principal": "*"  // identifies all principals including AWS Service principals
-    //
-    // S3 rewrites the AWS member of the policy on save so only the unique set of principals are included
-    // So after these machinations, we end up with what we want.
-    const denyEveryoneElsePrincipals = [new AnyPrincipal(), new AnyPrincipal()];
-
     const denyEveryoneElseTest = policyFactory.wasLikeUsed(props.k9DesiredAccess) ?
         'ArnNotLike' :
         'ArnNotEquals';
     const denyEveryoneElseStatement = new PolicyStatement({
                 sid: 'DenyEveryoneElse',
                 effect: Effect.DENY,
-                principals: denyEveryoneElsePrincipals,
+                principals: policyFactory.makeDenyEveryoneElsePrincipals(),
                 actions: ['s3:*'],
                 resources: resourceArns
             });

--- a/test/__snapshots__/k9.test.ts.snap
+++ b/test/__snapshots__/k9.test.ts.snap
@@ -382,22 +382,10 @@ Object {
               },
               "Effect": "Deny",
               "Principal": Object {
-                "AWS": Object {
-                  "Fn::Join": Array [
-                    "",
-                    Array [
-                      "arn:",
-                      Object {
-                        "Ref": "AWS::Partition",
-                      },
-                      ":iam::",
-                      Object {
-                        "Ref": "AWS::AccountId",
-                      },
-                      ":root",
-                    ],
-                  ],
-                },
+                "AWS": Array [
+                  "*",
+                  "*",
+                ],
               },
               "Resource": Array [
                 Object {
@@ -820,22 +808,10 @@ Object {
               },
               "Effect": "Deny",
               "Principal": Object {
-                "AWS": Object {
-                  "Fn::Join": Array [
-                    "",
-                    Array [
-                      "arn:",
-                      Object {
-                        "Ref": "AWS::Partition",
-                      },
-                      ":iam::",
-                      Object {
-                        "Ref": "AWS::AccountId",
-                      },
-                      ":root",
-                    ],
-                  ],
-                },
+                "AWS": Array [
+                  "*",
+                  "*",
+                ],
               },
               "Resource": Array [
                 Object {

--- a/test/__snapshots__/k9.test.ts.snap
+++ b/test/__snapshots__/k9.test.ts.snap
@@ -1012,22 +1012,10 @@ Object {
               },
               "Effect": "Deny",
               "Principal": Object {
-                "AWS": Object {
-                  "Fn::Join": Array [
-                    "",
-                    Array [
-                      "arn:",
-                      Object {
-                        "Ref": "AWS::Partition",
-                      },
-                      ":iam::",
-                      Object {
-                        "Ref": "AWS::AccountId",
-                      },
-                      ":root",
-                    ],
-                  ],
-                },
+                "AWS": Array [
+                  "*",
+                  "*",
+                ],
               },
               "Resource": "*",
               "Sid": "DenyEveryoneElse",

--- a/test/k9policy.test.ts
+++ b/test/k9policy.test.ts
@@ -1,5 +1,6 @@
 import * as k9policy from "../lib/k9policy";
 import {AccessCapability, AccessSpec} from "../lib/k9policy";
+import {AnyPrincipal} from "@aws-cdk/aws-iam";
 
 test('K9PolicyFactory#wasLikeUsed', () => {
     let k9PolicyFactory = new k9policy.K9PolicyFactory();
@@ -39,4 +40,15 @@ test('K9PolicyFactory#getAllowedPrincipalArns', () => {
     expect(k9PolicyFactory.getAllowedPrincipalArns([])).toEqual(new Set<string>());
     expect(k9PolicyFactory.getAllowedPrincipalArns(accessSpecs))
         .toEqual(new Set(["arn1", "arn2", "arn3"]));
+});
+
+test('K9PolicyFactory#makeDenyEveryoneElsePrincipals', () => {
+    let k9PolicyFactory = new k9policy.K9PolicyFactory();
+    let denyEveryoneElsePrincipals = k9PolicyFactory.makeDenyEveryoneElsePrincipals();
+    expect(denyEveryoneElsePrincipals.length).toBeGreaterThan(1);
+    const anyPrincipal = new AnyPrincipal();
+    for(let principal of denyEveryoneElsePrincipals){
+        expect(principal).toEqual(anyPrincipal);
+        expect(principal).toBeInstanceOf(AnyPrincipal);
+    }
 });


### PR DESCRIPTION
This change reintroduces Denying all AWS accounts and associated IAM in the `DenyEveryoneElse` statement.

In order to do this, k9-cdk works around unwanted merging & flattening of a single AWS principal wildcard, which is then promoted to 'All' principals.  This merge and promotion is undesirable because it applies to Service principals as well, creating problems for use of KMS by data services in particular.

See comments for [`K9PolicyFactory#makeDenyEveryoneElsePrincipals`](https://github.com/k9securityio/k9-cdk/pull/11/files#diff-27e630f6d8f8798a5f2b3b8b0706b768422c3772a78c9164217d8ee9a93dc47cR121)