### PR TITLE
CLOUD-777: Simplify KMS makeKeyPolicy signature

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,25 @@ const k9BucketPolicyProps: k9.s3.K9BucketPolicyProps = {
      )
 };
 
-k9.s3.makeBucketPolicy(stack, "S3Bucket", k9BucketPolicyProps);
+k9.s3.grantAccessViaResourcePolicy(stack, "S3Bucket", k9BucketPolicyProps);
+```
+
+Granting access to a KMS key is similar, but the custom resource policy is created first 
+so it can be set via `props` per CDK convention:
+ 
+```typescript
+import * as kms from "@aws-cdk/aws-kms"; 
+import {PolicyDocument} from "@aws-cdk/aws-iam";
+
+const k9KeyPolicyProps: k9.kms.K9KeyPolicyProps = {
+    k9DesiredAccess: k9BucketPolicyProps.k9DesiredAccess
+};
+const keyPolicy: PolicyDocument = k9.kms.makeKeyPolicy(k9KeyPolicyProps);
+
+new kms.Key(stack, 'KMSKey', {
+    alias: 'app-key-with-k9-policy',
+    policy: keyPolicy
+}); 
 ```
 
 The example stack demonstrates full use of the k9 S3 and KMS policy generators.  Generated policies:

--- a/bin/k9-cdk.ts
+++ b/bin/k9-cdk.ts
@@ -83,29 +83,11 @@ k9.s3.grantAccessViaResourcePolicy(stack, 'AutoDeleteBucket', k9AutoDeleteBucket
 
 console.log(`k9 autoDeleteBucket.policy: ${autoDeleteBucket.policy}`);
 
-
+// Now create a Key policy that grants access the same access
 const k9KeyPolicyProps: k9.kms.K9KeyPolicyProps = {
-    k9DesiredAccess: new Array<k9.k9policy.AccessSpec>(
-        {
-            accessCapability: k9.k9policy.AccessCapability.AdministerResource,
-            allowPrincipalArns: administerResourceArns,
-        },
-        {
-            accessCapability: k9.k9policy.AccessCapability.ReadConfig,
-            allowPrincipalArns: readConfigArns,
-        },
-        {
-            accessCapability: k9.k9policy.AccessCapability.WriteData,
-            allowPrincipalArns: writeDataArns,
-        },
-        {
-            accessCapability: k9.k9policy.AccessCapability.ReadData,
-            allowPrincipalArns: readDataArns,
-        }
-        // omit access spec for delete-data because it is unneeded
-    )
+    k9DesiredAccess: k9BucketPolicyProps.k9DesiredAccess
 };
-const keyPolicy = k9.kms.makeKeyPolicy(stack, "KMSKey", k9KeyPolicyProps);
+const keyPolicy = k9.kms.makeKeyPolicy(k9KeyPolicyProps);
 
 new kms.Key(stack, 'KMSKey', {
     alias: 'k9-cdk-integration-test',

--- a/lib/kms.ts
+++ b/lib/kms.ts
@@ -1,7 +1,6 @@
 import * as iam from "@aws-cdk/aws-iam";
 import {AccountRootPrincipal, Effect, PolicyDocument, PolicyStatement} from "@aws-cdk/aws-iam";
 import {AccessCapability, AccessSpec, K9PolicyFactory} from "./k9policy";
-import * as cdk from "@aws-cdk/core";
 
 export interface K9KeyPolicyProps {
     readonly k9DesiredAccess: Array<AccessSpec>
@@ -16,7 +15,7 @@ let SUPPORTED_CAPABILITIES = new Array<AccessCapability>(
 );
 
 
-export function makeKeyPolicy(scope: cdk.Construct, id: string, props: K9KeyPolicyProps): PolicyDocument {
+export function makeKeyPolicy(props: K9KeyPolicyProps): PolicyDocument {
     const policyFactory = new K9PolicyFactory();
     const policy = new iam.PolicyDocument();
 

--- a/test/k9.test.ts
+++ b/test/k9.test.ts
@@ -126,7 +126,7 @@ test('K9KeyPolicy', () => {
             },
         )
     };
-    const keyPolicy = k9.kms.makeKeyPolicy(stack, "KMSKey", k9KeyPolicyProps);
+    const keyPolicy = k9.kms.makeKeyPolicy(k9KeyPolicyProps);
 
     console.log("keyPolicy.document: " + stringifyPolicy(keyPolicy));
 


### PR DESCRIPTION
Simplify KMS makeKeyPolicy signature since it always creates a new policy.

In contrast to S3, always creating a new policy because it's not possible to:
 * inspect the contents of an existing Key policy
 * specify conditions when using grant(grantee, actions)