### PR TITLE
Exclude IAM principals from AWS services from DenyEveryoneElse

### DIFF
--- a/lib/kms.ts
+++ b/lib/kms.ts
@@ -34,6 +34,9 @@ export function makeKeyPolicy(props: K9KeyPolicyProps): PolicyDocument {
         actions: ['kms:*'],
         resources: resourceArns
     });
+    denyEveryoneElseStatement.addCondition('Bool', {
+        'aws:PrincipalIsAWSService': ["false"]
+    });
     const denyEveryoneElseTest = policyFactory.wasLikeUsed(props.k9DesiredAccess) ?
         'ArnNotLike' :
         'ArnNotEquals';

--- a/test/__snapshots__/k9.test.ts.snap
+++ b/test/__snapshots__/k9.test.ts.snap
@@ -1580,6 +1580,11 @@ Object {
                     "arn:aws:iam::139710491120:user/super-admin",
                   ],
                 },
+                "Bool": Object {
+                  "aws:PrincipalIsAWSService": Array [
+                    "false",
+                  ],
+                },
               },
               "Effect": "Deny",
               "Principal": Object {


### PR DESCRIPTION
Exclude IAM principals from AWS services from DenyEveryoneElse using `aws:PrincipalIsAWSService`.  This allows services like DynamoDB to use the key.