### PR TITLE
CLOUD-1139 support presigned urls with S3 managed encryption

### DIFF
--- a/lib/s3.ts
+++ b/lib/s3.ts
@@ -88,11 +88,10 @@ export function grantAccessViaResourcePolicy(scope: cdk.Construct, id: string, p
     denyEveryoneElseStatement.addCondition(denyEveryoneElseTest,
         {'aws:PrincipalArn': [...allAllowedPrincipalArns]});
 
-    // default encryption methdo to SSE-KMS,
+    // default encryption method to SSE-KMS,
     // allow override to SSE-S3 (AES256)
     let encryptionMethod = 'aws:kms'
     if(props.encryption){
-        //if(BucketEncryption.S3_MANAGED.valueOf() == props.encryption.valueOf()){
         if(BucketEncryption.S3_MANAGED == props.encryption){
             encryptionMethod = 'AES-256'
         }

--- a/test/__snapshots__/k9.test.ts.snap
+++ b/test/__snapshots__/k9.test.ts.snap
@@ -426,7 +426,7 @@ Object {
 }
 `;
 
-exports[`K9BucketPolicy 1`] = `
+exports[`K9BucketPolicy - typical usage 1`] = `
 Object {
   "Resources": Object {
     "S3BucketPolicy189C1E8E": Object {
@@ -1333,6 +1333,708 @@ Object {
                           "AutoDeleteBucket93E032C1",
                           "Arn",
                         ],
+                      },
+                      "/*",
+                    ],
+                  ],
+                },
+              ],
+              "Sid": "DenyEveryoneElse",
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+      },
+      "Type": "AWS::S3::BucketPolicy",
+    },
+    "BucketPolicyWithAlternateEncryptionMethodPolicy0BA38F4B": Object {
+      "Properties": Object {
+        "Bucket": Object {
+          "Fn::ImportValue": "K9BucketPolicyAlternateEncryptionMethod:ExportsOutputRefTestBucketWithAlternateEncryptionMethodF9AD985C29FC2EE9",
+        },
+        "PolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": Array [
+                "s3:DeleteBucket",
+                "s3:DeleteBucketPolicy",
+                "s3:DeleteBucketWebsite",
+                "s3:ObjectOwnerOverrideToBucketOwner",
+                "s3:PutAccelerateConfiguration",
+                "s3:PutAnalyticsConfiguration",
+                "s3:PutBucketAcl",
+                "s3:PutBucketCORS",
+                "s3:PutBucketLogging",
+                "s3:PutBucketNotification",
+                "s3:PutBucketObjectLockConfiguration",
+                "s3:PutBucketPolicy",
+                "s3:PutBucketPublicAccessBlock",
+                "s3:PutBucketRequestPayment",
+                "s3:PutBucketTagging",
+                "s3:PutBucketVersioning",
+                "s3:PutBucketWebsite",
+                "s3:PutEncryptionConfiguration",
+                "s3:PutInventoryConfiguration",
+                "s3:PutLifecycleConfiguration",
+                "s3:PutMetricsConfiguration",
+                "s3:PutObjectAcl",
+                "s3:PutObjectLegalHold",
+                "s3:PutObjectRetention",
+                "s3:PutObjectVersionAcl",
+                "s3:PutReplicationConfiguration",
+              ],
+              "Condition": Object {
+                "ArnEquals": Object {
+                  "aws:PrincipalArn": Array [
+                    "arn:aws:iam::139710491120:user/ci",
+                  ],
+                },
+              },
+              "Effect": "Allow",
+              "Principal": "*",
+              "Resource": Array [
+                Object {
+                  "Fn::ImportValue": "K9BucketPolicyAlternateEncryptionMethod:ExportsOutputFnGetAttTestBucketWithAlternateEncryptionMethodF9AD985CArn042A2492",
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      Object {
+                        "Fn::ImportValue": "K9BucketPolicyAlternateEncryptionMethod:ExportsOutputFnGetAttTestBucketWithAlternateEncryptionMethodF9AD985CArn042A2492",
+                      },
+                      "/*",
+                    ],
+                  ],
+                },
+              ],
+              "Sid": "Allow Restricted administer-resource",
+            },
+            Object {
+              "Action": Array [
+                "s3:GetAccelerateConfiguration",
+                "s3:GetAnalyticsConfiguration",
+                "s3:GetBucketAcl",
+                "s3:GetBucketCORS",
+                "s3:GetBucketLocation",
+                "s3:GetBucketLogging",
+                "s3:GetBucketNotification",
+                "s3:GetBucketObjectLockConfiguration",
+                "s3:GetBucketOwnershipControls",
+                "s3:GetBucketPolicy",
+                "s3:GetBucketPolicyStatus",
+                "s3:GetBucketPublicAccessBlock",
+                "s3:GetBucketRequestPayment",
+                "s3:GetBucketTagging",
+                "s3:GetBucketVersioning",
+                "s3:GetBucketWebsite",
+                "s3:GetEncryptionConfiguration",
+                "s3:GetInventoryConfiguration",
+                "s3:GetLifecycleConfiguration",
+                "s3:GetMetricsConfiguration",
+                "s3:GetObjectAcl",
+                "s3:GetObjectLegalHold",
+                "s3:GetObjectRetention",
+                "s3:GetObjectTagging",
+                "s3:GetObjectVersionAcl",
+                "s3:GetObjectVersionTagging",
+                "s3:GetReplicationConfiguration",
+                "s3:ListBucketMultipartUploads",
+                "s3:ListBucketVersions",
+                "s3:ListMultipartUploadParts",
+              ],
+              "Condition": Object {
+                "ArnEquals": Object {
+                  "aws:PrincipalArn": Array [],
+                },
+              },
+              "Effect": "Allow",
+              "Principal": "*",
+              "Resource": Array [
+                Object {
+                  "Fn::ImportValue": "K9BucketPolicyAlternateEncryptionMethod:ExportsOutputFnGetAttTestBucketWithAlternateEncryptionMethodF9AD985CArn042A2492",
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      Object {
+                        "Fn::ImportValue": "K9BucketPolicyAlternateEncryptionMethod:ExportsOutputFnGetAttTestBucketWithAlternateEncryptionMethodF9AD985CArn042A2492",
+                      },
+                      "/*",
+                    ],
+                  ],
+                },
+              ],
+              "Sid": "Allow Restricted read-config",
+            },
+            Object {
+              "Action": Array [
+                "s3:GetObject",
+                "s3:GetObjectTorrent",
+                "s3:GetObjectVersion",
+                "s3:GetObjectVersionForReplication",
+                "s3:GetObjectVersionTorrent",
+                "s3:ListBucket",
+              ],
+              "Condition": Object {
+                "ArnEquals": Object {
+                  "aws:PrincipalArn": Array [],
+                },
+              },
+              "Effect": "Allow",
+              "Principal": "*",
+              "Resource": Array [
+                Object {
+                  "Fn::ImportValue": "K9BucketPolicyAlternateEncryptionMethod:ExportsOutputFnGetAttTestBucketWithAlternateEncryptionMethodF9AD985CArn042A2492",
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      Object {
+                        "Fn::ImportValue": "K9BucketPolicyAlternateEncryptionMethod:ExportsOutputFnGetAttTestBucketWithAlternateEncryptionMethodF9AD985CArn042A2492",
+                      },
+                      "/*",
+                    ],
+                  ],
+                },
+              ],
+              "Sid": "Allow Restricted read-data",
+            },
+            Object {
+              "Action": Array [
+                "s3:AbortMultipartUpload",
+                "s3:PutBucketTagging",
+                "s3:PutObject",
+                "s3:PutObjectTagging",
+                "s3:PutObjectVersionTagging",
+                "s3:ReplicateDelete",
+                "s3:ReplicateObject",
+                "s3:ReplicateTags",
+                "s3:RestoreObject",
+              ],
+              "Condition": Object {
+                "ArnEquals": Object {
+                  "aws:PrincipalArn": Array [],
+                },
+              },
+              "Effect": "Allow",
+              "Principal": "*",
+              "Resource": Array [
+                Object {
+                  "Fn::ImportValue": "K9BucketPolicyAlternateEncryptionMethod:ExportsOutputFnGetAttTestBucketWithAlternateEncryptionMethodF9AD985CArn042A2492",
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      Object {
+                        "Fn::ImportValue": "K9BucketPolicyAlternateEncryptionMethod:ExportsOutputFnGetAttTestBucketWithAlternateEncryptionMethodF9AD985CArn042A2492",
+                      },
+                      "/*",
+                    ],
+                  ],
+                },
+              ],
+              "Sid": "Allow Restricted write-data",
+            },
+            Object {
+              "Action": Array [
+                "s3:DeleteObject",
+                "s3:DeleteObjectTagging",
+                "s3:DeleteObjectVersion",
+                "s3:DeleteObjectVersionTagging",
+              ],
+              "Condition": Object {
+                "ArnEquals": Object {
+                  "aws:PrincipalArn": Array [],
+                },
+              },
+              "Effect": "Allow",
+              "Principal": "*",
+              "Resource": Array [
+                Object {
+                  "Fn::ImportValue": "K9BucketPolicyAlternateEncryptionMethod:ExportsOutputFnGetAttTestBucketWithAlternateEncryptionMethodF9AD985CArn042A2492",
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      Object {
+                        "Fn::ImportValue": "K9BucketPolicyAlternateEncryptionMethod:ExportsOutputFnGetAttTestBucketWithAlternateEncryptionMethodF9AD985CArn042A2492",
+                      },
+                      "/*",
+                    ],
+                  ],
+                },
+              ],
+              "Sid": "Allow Restricted delete-data",
+            },
+            Object {
+              "Action": "s3:*",
+              "Condition": Object {
+                "Bool": Object {
+                  "aws:SecureTransport": false,
+                },
+              },
+              "Effect": "Deny",
+              "Principal": "*",
+              "Resource": Array [
+                Object {
+                  "Fn::ImportValue": "K9BucketPolicyAlternateEncryptionMethod:ExportsOutputFnGetAttTestBucketWithAlternateEncryptionMethodF9AD985CArn042A2492",
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      Object {
+                        "Fn::ImportValue": "K9BucketPolicyAlternateEncryptionMethod:ExportsOutputFnGetAttTestBucketWithAlternateEncryptionMethodF9AD985CArn042A2492",
+                      },
+                      "/*",
+                    ],
+                  ],
+                },
+              ],
+              "Sid": "DenyInsecureCommunications",
+            },
+            Object {
+              "Action": Array [
+                "s3:PutObject",
+                "s3:ReplicateObject",
+              ],
+              "Condition": Object {
+                "Null": Object {
+                  "s3:x-amz-server-side-encryption": true,
+                },
+              },
+              "Effect": "Deny",
+              "Principal": "*",
+              "Resource": Array [
+                Object {
+                  "Fn::ImportValue": "K9BucketPolicyAlternateEncryptionMethod:ExportsOutputFnGetAttTestBucketWithAlternateEncryptionMethodF9AD985CArn042A2492",
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      Object {
+                        "Fn::ImportValue": "K9BucketPolicyAlternateEncryptionMethod:ExportsOutputFnGetAttTestBucketWithAlternateEncryptionMethodF9AD985CArn042A2492",
+                      },
+                      "/*",
+                    ],
+                  ],
+                },
+              ],
+              "Sid": "DenyUnencryptedStorage",
+            },
+            Object {
+              "Action": Array [
+                "s3:PutObject",
+                "s3:ReplicateObject",
+              ],
+              "Condition": Object {
+                "StringNotEquals": Object {
+                  "s3:x-amz-server-side-encryption": "AES-256",
+                },
+              },
+              "Effect": "Deny",
+              "Principal": "*",
+              "Resource": Array [
+                Object {
+                  "Fn::ImportValue": "K9BucketPolicyAlternateEncryptionMethod:ExportsOutputFnGetAttTestBucketWithAlternateEncryptionMethodF9AD985CArn042A2492",
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      Object {
+                        "Fn::ImportValue": "K9BucketPolicyAlternateEncryptionMethod:ExportsOutputFnGetAttTestBucketWithAlternateEncryptionMethodF9AD985CArn042A2492",
+                      },
+                      "/*",
+                    ],
+                  ],
+                },
+              ],
+              "Sid": "DenyUnexpectedEncryptionMethod",
+            },
+            Object {
+              "Action": "s3:*",
+              "Condition": Object {
+                "ArnNotEquals": Object {
+                  "aws:PrincipalArn": Array [
+                    "arn:aws:iam::139710491120:user/ci",
+                  ],
+                },
+              },
+              "Effect": "Deny",
+              "Principal": Object {
+                "AWS": Array [
+                  "*",
+                  "*",
+                ],
+              },
+              "Resource": Array [
+                Object {
+                  "Fn::ImportValue": "K9BucketPolicyAlternateEncryptionMethod:ExportsOutputFnGetAttTestBucketWithAlternateEncryptionMethodF9AD985CArn042A2492",
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      Object {
+                        "Fn::ImportValue": "K9BucketPolicyAlternateEncryptionMethod:ExportsOutputFnGetAttTestBucketWithAlternateEncryptionMethodF9AD985CArn042A2492",
+                      },
+                      "/*",
+                    ],
+                  ],
+                },
+              ],
+              "Sid": "DenyEveryoneElse",
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+      },
+      "Type": "AWS::S3::BucketPolicy",
+    },
+    "BucketPolicyWithEncryptionMethodKMSPolicy8EA8A63A": Object {
+      "Properties": Object {
+        "Bucket": Object {
+          "Fn::ImportValue": "K9BucketPolicyWithEncryptionMethodKMS:ExportsOutputRefTestBucketWithEncryptionMethodKMSC063B9007C32753A",
+        },
+        "PolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": Array [
+                "s3:DeleteBucket",
+                "s3:DeleteBucketPolicy",
+                "s3:DeleteBucketWebsite",
+                "s3:ObjectOwnerOverrideToBucketOwner",
+                "s3:PutAccelerateConfiguration",
+                "s3:PutAnalyticsConfiguration",
+                "s3:PutBucketAcl",
+                "s3:PutBucketCORS",
+                "s3:PutBucketLogging",
+                "s3:PutBucketNotification",
+                "s3:PutBucketObjectLockConfiguration",
+                "s3:PutBucketPolicy",
+                "s3:PutBucketPublicAccessBlock",
+                "s3:PutBucketRequestPayment",
+                "s3:PutBucketTagging",
+                "s3:PutBucketVersioning",
+                "s3:PutBucketWebsite",
+                "s3:PutEncryptionConfiguration",
+                "s3:PutInventoryConfiguration",
+                "s3:PutLifecycleConfiguration",
+                "s3:PutMetricsConfiguration",
+                "s3:PutObjectAcl",
+                "s3:PutObjectLegalHold",
+                "s3:PutObjectRetention",
+                "s3:PutObjectVersionAcl",
+                "s3:PutReplicationConfiguration",
+              ],
+              "Condition": Object {
+                "ArnEquals": Object {
+                  "aws:PrincipalArn": Array [
+                    "arn:aws:iam::139710491120:user/ci",
+                  ],
+                },
+              },
+              "Effect": "Allow",
+              "Principal": "*",
+              "Resource": Array [
+                Object {
+                  "Fn::ImportValue": "K9BucketPolicyWithEncryptionMethodKMS:ExportsOutputFnGetAttTestBucketWithEncryptionMethodKMSC063B900ArnD6399430",
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      Object {
+                        "Fn::ImportValue": "K9BucketPolicyWithEncryptionMethodKMS:ExportsOutputFnGetAttTestBucketWithEncryptionMethodKMSC063B900ArnD6399430",
+                      },
+                      "/*",
+                    ],
+                  ],
+                },
+              ],
+              "Sid": "Allow Restricted administer-resource",
+            },
+            Object {
+              "Action": Array [
+                "s3:GetAccelerateConfiguration",
+                "s3:GetAnalyticsConfiguration",
+                "s3:GetBucketAcl",
+                "s3:GetBucketCORS",
+                "s3:GetBucketLocation",
+                "s3:GetBucketLogging",
+                "s3:GetBucketNotification",
+                "s3:GetBucketObjectLockConfiguration",
+                "s3:GetBucketOwnershipControls",
+                "s3:GetBucketPolicy",
+                "s3:GetBucketPolicyStatus",
+                "s3:GetBucketPublicAccessBlock",
+                "s3:GetBucketRequestPayment",
+                "s3:GetBucketTagging",
+                "s3:GetBucketVersioning",
+                "s3:GetBucketWebsite",
+                "s3:GetEncryptionConfiguration",
+                "s3:GetInventoryConfiguration",
+                "s3:GetLifecycleConfiguration",
+                "s3:GetMetricsConfiguration",
+                "s3:GetObjectAcl",
+                "s3:GetObjectLegalHold",
+                "s3:GetObjectRetention",
+                "s3:GetObjectTagging",
+                "s3:GetObjectVersionAcl",
+                "s3:GetObjectVersionTagging",
+                "s3:GetReplicationConfiguration",
+                "s3:ListBucketMultipartUploads",
+                "s3:ListBucketVersions",
+                "s3:ListMultipartUploadParts",
+              ],
+              "Condition": Object {
+                "ArnEquals": Object {
+                  "aws:PrincipalArn": Array [],
+                },
+              },
+              "Effect": "Allow",
+              "Principal": "*",
+              "Resource": Array [
+                Object {
+                  "Fn::ImportValue": "K9BucketPolicyWithEncryptionMethodKMS:ExportsOutputFnGetAttTestBucketWithEncryptionMethodKMSC063B900ArnD6399430",
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      Object {
+                        "Fn::ImportValue": "K9BucketPolicyWithEncryptionMethodKMS:ExportsOutputFnGetAttTestBucketWithEncryptionMethodKMSC063B900ArnD6399430",
+                      },
+                      "/*",
+                    ],
+                  ],
+                },
+              ],
+              "Sid": "Allow Restricted read-config",
+            },
+            Object {
+              "Action": Array [
+                "s3:GetObject",
+                "s3:GetObjectTorrent",
+                "s3:GetObjectVersion",
+                "s3:GetObjectVersionForReplication",
+                "s3:GetObjectVersionTorrent",
+                "s3:ListBucket",
+              ],
+              "Condition": Object {
+                "ArnEquals": Object {
+                  "aws:PrincipalArn": Array [],
+                },
+              },
+              "Effect": "Allow",
+              "Principal": "*",
+              "Resource": Array [
+                Object {
+                  "Fn::ImportValue": "K9BucketPolicyWithEncryptionMethodKMS:ExportsOutputFnGetAttTestBucketWithEncryptionMethodKMSC063B900ArnD6399430",
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      Object {
+                        "Fn::ImportValue": "K9BucketPolicyWithEncryptionMethodKMS:ExportsOutputFnGetAttTestBucketWithEncryptionMethodKMSC063B900ArnD6399430",
+                      },
+                      "/*",
+                    ],
+                  ],
+                },
+              ],
+              "Sid": "Allow Restricted read-data",
+            },
+            Object {
+              "Action": Array [
+                "s3:AbortMultipartUpload",
+                "s3:PutBucketTagging",
+                "s3:PutObject",
+                "s3:PutObjectTagging",
+                "s3:PutObjectVersionTagging",
+                "s3:ReplicateDelete",
+                "s3:ReplicateObject",
+                "s3:ReplicateTags",
+                "s3:RestoreObject",
+              ],
+              "Condition": Object {
+                "ArnEquals": Object {
+                  "aws:PrincipalArn": Array [],
+                },
+              },
+              "Effect": "Allow",
+              "Principal": "*",
+              "Resource": Array [
+                Object {
+                  "Fn::ImportValue": "K9BucketPolicyWithEncryptionMethodKMS:ExportsOutputFnGetAttTestBucketWithEncryptionMethodKMSC063B900ArnD6399430",
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      Object {
+                        "Fn::ImportValue": "K9BucketPolicyWithEncryptionMethodKMS:ExportsOutputFnGetAttTestBucketWithEncryptionMethodKMSC063B900ArnD6399430",
+                      },
+                      "/*",
+                    ],
+                  ],
+                },
+              ],
+              "Sid": "Allow Restricted write-data",
+            },
+            Object {
+              "Action": Array [
+                "s3:DeleteObject",
+                "s3:DeleteObjectTagging",
+                "s3:DeleteObjectVersion",
+                "s3:DeleteObjectVersionTagging",
+              ],
+              "Condition": Object {
+                "ArnEquals": Object {
+                  "aws:PrincipalArn": Array [],
+                },
+              },
+              "Effect": "Allow",
+              "Principal": "*",
+              "Resource": Array [
+                Object {
+                  "Fn::ImportValue": "K9BucketPolicyWithEncryptionMethodKMS:ExportsOutputFnGetAttTestBucketWithEncryptionMethodKMSC063B900ArnD6399430",
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      Object {
+                        "Fn::ImportValue": "K9BucketPolicyWithEncryptionMethodKMS:ExportsOutputFnGetAttTestBucketWithEncryptionMethodKMSC063B900ArnD6399430",
+                      },
+                      "/*",
+                    ],
+                  ],
+                },
+              ],
+              "Sid": "Allow Restricted delete-data",
+            },
+            Object {
+              "Action": "s3:*",
+              "Condition": Object {
+                "Bool": Object {
+                  "aws:SecureTransport": false,
+                },
+              },
+              "Effect": "Deny",
+              "Principal": "*",
+              "Resource": Array [
+                Object {
+                  "Fn::ImportValue": "K9BucketPolicyWithEncryptionMethodKMS:ExportsOutputFnGetAttTestBucketWithEncryptionMethodKMSC063B900ArnD6399430",
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      Object {
+                        "Fn::ImportValue": "K9BucketPolicyWithEncryptionMethodKMS:ExportsOutputFnGetAttTestBucketWithEncryptionMethodKMSC063B900ArnD6399430",
+                      },
+                      "/*",
+                    ],
+                  ],
+                },
+              ],
+              "Sid": "DenyInsecureCommunications",
+            },
+            Object {
+              "Action": Array [
+                "s3:PutObject",
+                "s3:ReplicateObject",
+              ],
+              "Condition": Object {
+                "Null": Object {
+                  "s3:x-amz-server-side-encryption": true,
+                },
+              },
+              "Effect": "Deny",
+              "Principal": "*",
+              "Resource": Array [
+                Object {
+                  "Fn::ImportValue": "K9BucketPolicyWithEncryptionMethodKMS:ExportsOutputFnGetAttTestBucketWithEncryptionMethodKMSC063B900ArnD6399430",
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      Object {
+                        "Fn::ImportValue": "K9BucketPolicyWithEncryptionMethodKMS:ExportsOutputFnGetAttTestBucketWithEncryptionMethodKMSC063B900ArnD6399430",
+                      },
+                      "/*",
+                    ],
+                  ],
+                },
+              ],
+              "Sid": "DenyUnencryptedStorage",
+            },
+            Object {
+              "Action": Array [
+                "s3:PutObject",
+                "s3:ReplicateObject",
+              ],
+              "Condition": Object {
+                "StringNotEquals": Object {
+                  "s3:x-amz-server-side-encryption": "aws:kms",
+                },
+              },
+              "Effect": "Deny",
+              "Principal": "*",
+              "Resource": Array [
+                Object {
+                  "Fn::ImportValue": "K9BucketPolicyWithEncryptionMethodKMS:ExportsOutputFnGetAttTestBucketWithEncryptionMethodKMSC063B900ArnD6399430",
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      Object {
+                        "Fn::ImportValue": "K9BucketPolicyWithEncryptionMethodKMS:ExportsOutputFnGetAttTestBucketWithEncryptionMethodKMSC063B900ArnD6399430",
+                      },
+                      "/*",
+                    ],
+                  ],
+                },
+              ],
+              "Sid": "DenyUnexpectedEncryptionMethod",
+            },
+            Object {
+              "Action": "s3:*",
+              "Condition": Object {
+                "ArnNotEquals": Object {
+                  "aws:PrincipalArn": Array [
+                    "arn:aws:iam::139710491120:user/ci",
+                  ],
+                },
+              },
+              "Effect": "Deny",
+              "Principal": Object {
+                "AWS": Array [
+                  "*",
+                  "*",
+                ],
+              },
+              "Resource": Array [
+                Object {
+                  "Fn::ImportValue": "K9BucketPolicyWithEncryptionMethodKMS:ExportsOutputFnGetAttTestBucketWithEncryptionMethodKMSC063B900ArnD6399430",
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      Object {
+                        "Fn::ImportValue": "K9BucketPolicyWithEncryptionMethodKMS:ExportsOutputFnGetAttTestBucketWithEncryptionMethodKMSC063B900ArnD6399430",
                       },
                       "/*",
                     ],
@@ -2773,6 +3475,708 @@ Object {
       },
       "Type": "AWS::S3::BucketPolicy",
     },
+    "BucketPolicyWithAlternateEncryptionMethodPolicy0BA38F4B": Object {
+      "Properties": Object {
+        "Bucket": Object {
+          "Fn::ImportValue": "K9BucketPolicyAlternateEncryptionMethod:ExportsOutputRefTestBucketWithAlternateEncryptionMethodF9AD985C29FC2EE9",
+        },
+        "PolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": Array [
+                "s3:DeleteBucket",
+                "s3:DeleteBucketPolicy",
+                "s3:DeleteBucketWebsite",
+                "s3:ObjectOwnerOverrideToBucketOwner",
+                "s3:PutAccelerateConfiguration",
+                "s3:PutAnalyticsConfiguration",
+                "s3:PutBucketAcl",
+                "s3:PutBucketCORS",
+                "s3:PutBucketLogging",
+                "s3:PutBucketNotification",
+                "s3:PutBucketObjectLockConfiguration",
+                "s3:PutBucketPolicy",
+                "s3:PutBucketPublicAccessBlock",
+                "s3:PutBucketRequestPayment",
+                "s3:PutBucketTagging",
+                "s3:PutBucketVersioning",
+                "s3:PutBucketWebsite",
+                "s3:PutEncryptionConfiguration",
+                "s3:PutInventoryConfiguration",
+                "s3:PutLifecycleConfiguration",
+                "s3:PutMetricsConfiguration",
+                "s3:PutObjectAcl",
+                "s3:PutObjectLegalHold",
+                "s3:PutObjectRetention",
+                "s3:PutObjectVersionAcl",
+                "s3:PutReplicationConfiguration",
+              ],
+              "Condition": Object {
+                "ArnEquals": Object {
+                  "aws:PrincipalArn": Array [
+                    "arn:aws:iam::139710491120:user/ci",
+                  ],
+                },
+              },
+              "Effect": "Allow",
+              "Principal": "*",
+              "Resource": Array [
+                Object {
+                  "Fn::ImportValue": "K9BucketPolicyAlternateEncryptionMethod:ExportsOutputFnGetAttTestBucketWithAlternateEncryptionMethodF9AD985CArn042A2492",
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      Object {
+                        "Fn::ImportValue": "K9BucketPolicyAlternateEncryptionMethod:ExportsOutputFnGetAttTestBucketWithAlternateEncryptionMethodF9AD985CArn042A2492",
+                      },
+                      "/*",
+                    ],
+                  ],
+                },
+              ],
+              "Sid": "Allow Restricted administer-resource",
+            },
+            Object {
+              "Action": Array [
+                "s3:GetAccelerateConfiguration",
+                "s3:GetAnalyticsConfiguration",
+                "s3:GetBucketAcl",
+                "s3:GetBucketCORS",
+                "s3:GetBucketLocation",
+                "s3:GetBucketLogging",
+                "s3:GetBucketNotification",
+                "s3:GetBucketObjectLockConfiguration",
+                "s3:GetBucketOwnershipControls",
+                "s3:GetBucketPolicy",
+                "s3:GetBucketPolicyStatus",
+                "s3:GetBucketPublicAccessBlock",
+                "s3:GetBucketRequestPayment",
+                "s3:GetBucketTagging",
+                "s3:GetBucketVersioning",
+                "s3:GetBucketWebsite",
+                "s3:GetEncryptionConfiguration",
+                "s3:GetInventoryConfiguration",
+                "s3:GetLifecycleConfiguration",
+                "s3:GetMetricsConfiguration",
+                "s3:GetObjectAcl",
+                "s3:GetObjectLegalHold",
+                "s3:GetObjectRetention",
+                "s3:GetObjectTagging",
+                "s3:GetObjectVersionAcl",
+                "s3:GetObjectVersionTagging",
+                "s3:GetReplicationConfiguration",
+                "s3:ListBucketMultipartUploads",
+                "s3:ListBucketVersions",
+                "s3:ListMultipartUploadParts",
+              ],
+              "Condition": Object {
+                "ArnEquals": Object {
+                  "aws:PrincipalArn": Array [],
+                },
+              },
+              "Effect": "Allow",
+              "Principal": "*",
+              "Resource": Array [
+                Object {
+                  "Fn::ImportValue": "K9BucketPolicyAlternateEncryptionMethod:ExportsOutputFnGetAttTestBucketWithAlternateEncryptionMethodF9AD985CArn042A2492",
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      Object {
+                        "Fn::ImportValue": "K9BucketPolicyAlternateEncryptionMethod:ExportsOutputFnGetAttTestBucketWithAlternateEncryptionMethodF9AD985CArn042A2492",
+                      },
+                      "/*",
+                    ],
+                  ],
+                },
+              ],
+              "Sid": "Allow Restricted read-config",
+            },
+            Object {
+              "Action": Array [
+                "s3:GetObject",
+                "s3:GetObjectTorrent",
+                "s3:GetObjectVersion",
+                "s3:GetObjectVersionForReplication",
+                "s3:GetObjectVersionTorrent",
+                "s3:ListBucket",
+              ],
+              "Condition": Object {
+                "ArnEquals": Object {
+                  "aws:PrincipalArn": Array [],
+                },
+              },
+              "Effect": "Allow",
+              "Principal": "*",
+              "Resource": Array [
+                Object {
+                  "Fn::ImportValue": "K9BucketPolicyAlternateEncryptionMethod:ExportsOutputFnGetAttTestBucketWithAlternateEncryptionMethodF9AD985CArn042A2492",
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      Object {
+                        "Fn::ImportValue": "K9BucketPolicyAlternateEncryptionMethod:ExportsOutputFnGetAttTestBucketWithAlternateEncryptionMethodF9AD985CArn042A2492",
+                      },
+                      "/*",
+                    ],
+                  ],
+                },
+              ],
+              "Sid": "Allow Restricted read-data",
+            },
+            Object {
+              "Action": Array [
+                "s3:AbortMultipartUpload",
+                "s3:PutBucketTagging",
+                "s3:PutObject",
+                "s3:PutObjectTagging",
+                "s3:PutObjectVersionTagging",
+                "s3:ReplicateDelete",
+                "s3:ReplicateObject",
+                "s3:ReplicateTags",
+                "s3:RestoreObject",
+              ],
+              "Condition": Object {
+                "ArnEquals": Object {
+                  "aws:PrincipalArn": Array [],
+                },
+              },
+              "Effect": "Allow",
+              "Principal": "*",
+              "Resource": Array [
+                Object {
+                  "Fn::ImportValue": "K9BucketPolicyAlternateEncryptionMethod:ExportsOutputFnGetAttTestBucketWithAlternateEncryptionMethodF9AD985CArn042A2492",
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      Object {
+                        "Fn::ImportValue": "K9BucketPolicyAlternateEncryptionMethod:ExportsOutputFnGetAttTestBucketWithAlternateEncryptionMethodF9AD985CArn042A2492",
+                      },
+                      "/*",
+                    ],
+                  ],
+                },
+              ],
+              "Sid": "Allow Restricted write-data",
+            },
+            Object {
+              "Action": Array [
+                "s3:DeleteObject",
+                "s3:DeleteObjectTagging",
+                "s3:DeleteObjectVersion",
+                "s3:DeleteObjectVersionTagging",
+              ],
+              "Condition": Object {
+                "ArnEquals": Object {
+                  "aws:PrincipalArn": Array [],
+                },
+              },
+              "Effect": "Allow",
+              "Principal": "*",
+              "Resource": Array [
+                Object {
+                  "Fn::ImportValue": "K9BucketPolicyAlternateEncryptionMethod:ExportsOutputFnGetAttTestBucketWithAlternateEncryptionMethodF9AD985CArn042A2492",
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      Object {
+                        "Fn::ImportValue": "K9BucketPolicyAlternateEncryptionMethod:ExportsOutputFnGetAttTestBucketWithAlternateEncryptionMethodF9AD985CArn042A2492",
+                      },
+                      "/*",
+                    ],
+                  ],
+                },
+              ],
+              "Sid": "Allow Restricted delete-data",
+            },
+            Object {
+              "Action": "s3:*",
+              "Condition": Object {
+                "Bool": Object {
+                  "aws:SecureTransport": false,
+                },
+              },
+              "Effect": "Deny",
+              "Principal": "*",
+              "Resource": Array [
+                Object {
+                  "Fn::ImportValue": "K9BucketPolicyAlternateEncryptionMethod:ExportsOutputFnGetAttTestBucketWithAlternateEncryptionMethodF9AD985CArn042A2492",
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      Object {
+                        "Fn::ImportValue": "K9BucketPolicyAlternateEncryptionMethod:ExportsOutputFnGetAttTestBucketWithAlternateEncryptionMethodF9AD985CArn042A2492",
+                      },
+                      "/*",
+                    ],
+                  ],
+                },
+              ],
+              "Sid": "DenyInsecureCommunications",
+            },
+            Object {
+              "Action": Array [
+                "s3:PutObject",
+                "s3:ReplicateObject",
+              ],
+              "Condition": Object {
+                "Null": Object {
+                  "s3:x-amz-server-side-encryption": true,
+                },
+              },
+              "Effect": "Deny",
+              "Principal": "*",
+              "Resource": Array [
+                Object {
+                  "Fn::ImportValue": "K9BucketPolicyAlternateEncryptionMethod:ExportsOutputFnGetAttTestBucketWithAlternateEncryptionMethodF9AD985CArn042A2492",
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      Object {
+                        "Fn::ImportValue": "K9BucketPolicyAlternateEncryptionMethod:ExportsOutputFnGetAttTestBucketWithAlternateEncryptionMethodF9AD985CArn042A2492",
+                      },
+                      "/*",
+                    ],
+                  ],
+                },
+              ],
+              "Sid": "DenyUnencryptedStorage",
+            },
+            Object {
+              "Action": Array [
+                "s3:PutObject",
+                "s3:ReplicateObject",
+              ],
+              "Condition": Object {
+                "StringNotEquals": Object {
+                  "s3:x-amz-server-side-encryption": "AES-256",
+                },
+              },
+              "Effect": "Deny",
+              "Principal": "*",
+              "Resource": Array [
+                Object {
+                  "Fn::ImportValue": "K9BucketPolicyAlternateEncryptionMethod:ExportsOutputFnGetAttTestBucketWithAlternateEncryptionMethodF9AD985CArn042A2492",
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      Object {
+                        "Fn::ImportValue": "K9BucketPolicyAlternateEncryptionMethod:ExportsOutputFnGetAttTestBucketWithAlternateEncryptionMethodF9AD985CArn042A2492",
+                      },
+                      "/*",
+                    ],
+                  ],
+                },
+              ],
+              "Sid": "DenyUnexpectedEncryptionMethod",
+            },
+            Object {
+              "Action": "s3:*",
+              "Condition": Object {
+                "ArnNotEquals": Object {
+                  "aws:PrincipalArn": Array [
+                    "arn:aws:iam::139710491120:user/ci",
+                  ],
+                },
+              },
+              "Effect": "Deny",
+              "Principal": Object {
+                "AWS": Array [
+                  "*",
+                  "*",
+                ],
+              },
+              "Resource": Array [
+                Object {
+                  "Fn::ImportValue": "K9BucketPolicyAlternateEncryptionMethod:ExportsOutputFnGetAttTestBucketWithAlternateEncryptionMethodF9AD985CArn042A2492",
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      Object {
+                        "Fn::ImportValue": "K9BucketPolicyAlternateEncryptionMethod:ExportsOutputFnGetAttTestBucketWithAlternateEncryptionMethodF9AD985CArn042A2492",
+                      },
+                      "/*",
+                    ],
+                  ],
+                },
+              ],
+              "Sid": "DenyEveryoneElse",
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+      },
+      "Type": "AWS::S3::BucketPolicy",
+    },
+    "BucketPolicyWithEncryptionMethodKMSPolicy8EA8A63A": Object {
+      "Properties": Object {
+        "Bucket": Object {
+          "Fn::ImportValue": "K9BucketPolicyWithEncryptionMethodKMS:ExportsOutputRefTestBucketWithEncryptionMethodKMSC063B9007C32753A",
+        },
+        "PolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": Array [
+                "s3:DeleteBucket",
+                "s3:DeleteBucketPolicy",
+                "s3:DeleteBucketWebsite",
+                "s3:ObjectOwnerOverrideToBucketOwner",
+                "s3:PutAccelerateConfiguration",
+                "s3:PutAnalyticsConfiguration",
+                "s3:PutBucketAcl",
+                "s3:PutBucketCORS",
+                "s3:PutBucketLogging",
+                "s3:PutBucketNotification",
+                "s3:PutBucketObjectLockConfiguration",
+                "s3:PutBucketPolicy",
+                "s3:PutBucketPublicAccessBlock",
+                "s3:PutBucketRequestPayment",
+                "s3:PutBucketTagging",
+                "s3:PutBucketVersioning",
+                "s3:PutBucketWebsite",
+                "s3:PutEncryptionConfiguration",
+                "s3:PutInventoryConfiguration",
+                "s3:PutLifecycleConfiguration",
+                "s3:PutMetricsConfiguration",
+                "s3:PutObjectAcl",
+                "s3:PutObjectLegalHold",
+                "s3:PutObjectRetention",
+                "s3:PutObjectVersionAcl",
+                "s3:PutReplicationConfiguration",
+              ],
+              "Condition": Object {
+                "ArnEquals": Object {
+                  "aws:PrincipalArn": Array [
+                    "arn:aws:iam::139710491120:user/ci",
+                  ],
+                },
+              },
+              "Effect": "Allow",
+              "Principal": "*",
+              "Resource": Array [
+                Object {
+                  "Fn::ImportValue": "K9BucketPolicyWithEncryptionMethodKMS:ExportsOutputFnGetAttTestBucketWithEncryptionMethodKMSC063B900ArnD6399430",
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      Object {
+                        "Fn::ImportValue": "K9BucketPolicyWithEncryptionMethodKMS:ExportsOutputFnGetAttTestBucketWithEncryptionMethodKMSC063B900ArnD6399430",
+                      },
+                      "/*",
+                    ],
+                  ],
+                },
+              ],
+              "Sid": "Allow Restricted administer-resource",
+            },
+            Object {
+              "Action": Array [
+                "s3:GetAccelerateConfiguration",
+                "s3:GetAnalyticsConfiguration",
+                "s3:GetBucketAcl",
+                "s3:GetBucketCORS",
+                "s3:GetBucketLocation",
+                "s3:GetBucketLogging",
+                "s3:GetBucketNotification",
+                "s3:GetBucketObjectLockConfiguration",
+                "s3:GetBucketOwnershipControls",
+                "s3:GetBucketPolicy",
+                "s3:GetBucketPolicyStatus",
+                "s3:GetBucketPublicAccessBlock",
+                "s3:GetBucketRequestPayment",
+                "s3:GetBucketTagging",
+                "s3:GetBucketVersioning",
+                "s3:GetBucketWebsite",
+                "s3:GetEncryptionConfiguration",
+                "s3:GetInventoryConfiguration",
+                "s3:GetLifecycleConfiguration",
+                "s3:GetMetricsConfiguration",
+                "s3:GetObjectAcl",
+                "s3:GetObjectLegalHold",
+                "s3:GetObjectRetention",
+                "s3:GetObjectTagging",
+                "s3:GetObjectVersionAcl",
+                "s3:GetObjectVersionTagging",
+                "s3:GetReplicationConfiguration",
+                "s3:ListBucketMultipartUploads",
+                "s3:ListBucketVersions",
+                "s3:ListMultipartUploadParts",
+              ],
+              "Condition": Object {
+                "ArnEquals": Object {
+                  "aws:PrincipalArn": Array [],
+                },
+              },
+              "Effect": "Allow",
+              "Principal": "*",
+              "Resource": Array [
+                Object {
+                  "Fn::ImportValue": "K9BucketPolicyWithEncryptionMethodKMS:ExportsOutputFnGetAttTestBucketWithEncryptionMethodKMSC063B900ArnD6399430",
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      Object {
+                        "Fn::ImportValue": "K9BucketPolicyWithEncryptionMethodKMS:ExportsOutputFnGetAttTestBucketWithEncryptionMethodKMSC063B900ArnD6399430",
+                      },
+                      "/*",
+                    ],
+                  ],
+                },
+              ],
+              "Sid": "Allow Restricted read-config",
+            },
+            Object {
+              "Action": Array [
+                "s3:GetObject",
+                "s3:GetObjectTorrent",
+                "s3:GetObjectVersion",
+                "s3:GetObjectVersionForReplication",
+                "s3:GetObjectVersionTorrent",
+                "s3:ListBucket",
+              ],
+              "Condition": Object {
+                "ArnEquals": Object {
+                  "aws:PrincipalArn": Array [],
+                },
+              },
+              "Effect": "Allow",
+              "Principal": "*",
+              "Resource": Array [
+                Object {
+                  "Fn::ImportValue": "K9BucketPolicyWithEncryptionMethodKMS:ExportsOutputFnGetAttTestBucketWithEncryptionMethodKMSC063B900ArnD6399430",
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      Object {
+                        "Fn::ImportValue": "K9BucketPolicyWithEncryptionMethodKMS:ExportsOutputFnGetAttTestBucketWithEncryptionMethodKMSC063B900ArnD6399430",
+                      },
+                      "/*",
+                    ],
+                  ],
+                },
+              ],
+              "Sid": "Allow Restricted read-data",
+            },
+            Object {
+              "Action": Array [
+                "s3:AbortMultipartUpload",
+                "s3:PutBucketTagging",
+                "s3:PutObject",
+                "s3:PutObjectTagging",
+                "s3:PutObjectVersionTagging",
+                "s3:ReplicateDelete",
+                "s3:ReplicateObject",
+                "s3:ReplicateTags",
+                "s3:RestoreObject",
+              ],
+              "Condition": Object {
+                "ArnEquals": Object {
+                  "aws:PrincipalArn": Array [],
+                },
+              },
+              "Effect": "Allow",
+              "Principal": "*",
+              "Resource": Array [
+                Object {
+                  "Fn::ImportValue": "K9BucketPolicyWithEncryptionMethodKMS:ExportsOutputFnGetAttTestBucketWithEncryptionMethodKMSC063B900ArnD6399430",
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      Object {
+                        "Fn::ImportValue": "K9BucketPolicyWithEncryptionMethodKMS:ExportsOutputFnGetAttTestBucketWithEncryptionMethodKMSC063B900ArnD6399430",
+                      },
+                      "/*",
+                    ],
+                  ],
+                },
+              ],
+              "Sid": "Allow Restricted write-data",
+            },
+            Object {
+              "Action": Array [
+                "s3:DeleteObject",
+                "s3:DeleteObjectTagging",
+                "s3:DeleteObjectVersion",
+                "s3:DeleteObjectVersionTagging",
+              ],
+              "Condition": Object {
+                "ArnEquals": Object {
+                  "aws:PrincipalArn": Array [],
+                },
+              },
+              "Effect": "Allow",
+              "Principal": "*",
+              "Resource": Array [
+                Object {
+                  "Fn::ImportValue": "K9BucketPolicyWithEncryptionMethodKMS:ExportsOutputFnGetAttTestBucketWithEncryptionMethodKMSC063B900ArnD6399430",
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      Object {
+                        "Fn::ImportValue": "K9BucketPolicyWithEncryptionMethodKMS:ExportsOutputFnGetAttTestBucketWithEncryptionMethodKMSC063B900ArnD6399430",
+                      },
+                      "/*",
+                    ],
+                  ],
+                },
+              ],
+              "Sid": "Allow Restricted delete-data",
+            },
+            Object {
+              "Action": "s3:*",
+              "Condition": Object {
+                "Bool": Object {
+                  "aws:SecureTransport": false,
+                },
+              },
+              "Effect": "Deny",
+              "Principal": "*",
+              "Resource": Array [
+                Object {
+                  "Fn::ImportValue": "K9BucketPolicyWithEncryptionMethodKMS:ExportsOutputFnGetAttTestBucketWithEncryptionMethodKMSC063B900ArnD6399430",
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      Object {
+                        "Fn::ImportValue": "K9BucketPolicyWithEncryptionMethodKMS:ExportsOutputFnGetAttTestBucketWithEncryptionMethodKMSC063B900ArnD6399430",
+                      },
+                      "/*",
+                    ],
+                  ],
+                },
+              ],
+              "Sid": "DenyInsecureCommunications",
+            },
+            Object {
+              "Action": Array [
+                "s3:PutObject",
+                "s3:ReplicateObject",
+              ],
+              "Condition": Object {
+                "Null": Object {
+                  "s3:x-amz-server-side-encryption": true,
+                },
+              },
+              "Effect": "Deny",
+              "Principal": "*",
+              "Resource": Array [
+                Object {
+                  "Fn::ImportValue": "K9BucketPolicyWithEncryptionMethodKMS:ExportsOutputFnGetAttTestBucketWithEncryptionMethodKMSC063B900ArnD6399430",
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      Object {
+                        "Fn::ImportValue": "K9BucketPolicyWithEncryptionMethodKMS:ExportsOutputFnGetAttTestBucketWithEncryptionMethodKMSC063B900ArnD6399430",
+                      },
+                      "/*",
+                    ],
+                  ],
+                },
+              ],
+              "Sid": "DenyUnencryptedStorage",
+            },
+            Object {
+              "Action": Array [
+                "s3:PutObject",
+                "s3:ReplicateObject",
+              ],
+              "Condition": Object {
+                "StringNotEquals": Object {
+                  "s3:x-amz-server-side-encryption": "aws:kms",
+                },
+              },
+              "Effect": "Deny",
+              "Principal": "*",
+              "Resource": Array [
+                Object {
+                  "Fn::ImportValue": "K9BucketPolicyWithEncryptionMethodKMS:ExportsOutputFnGetAttTestBucketWithEncryptionMethodKMSC063B900ArnD6399430",
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      Object {
+                        "Fn::ImportValue": "K9BucketPolicyWithEncryptionMethodKMS:ExportsOutputFnGetAttTestBucketWithEncryptionMethodKMSC063B900ArnD6399430",
+                      },
+                      "/*",
+                    ],
+                  ],
+                },
+              ],
+              "Sid": "DenyUnexpectedEncryptionMethod",
+            },
+            Object {
+              "Action": "s3:*",
+              "Condition": Object {
+                "ArnNotEquals": Object {
+                  "aws:PrincipalArn": Array [
+                    "arn:aws:iam::139710491120:user/ci",
+                  ],
+                },
+              },
+              "Effect": "Deny",
+              "Principal": Object {
+                "AWS": Array [
+                  "*",
+                  "*",
+                ],
+              },
+              "Resource": Array [
+                Object {
+                  "Fn::ImportValue": "K9BucketPolicyWithEncryptionMethodKMS:ExportsOutputFnGetAttTestBucketWithEncryptionMethodKMSC063B900ArnD6399430",
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      Object {
+                        "Fn::ImportValue": "K9BucketPolicyWithEncryptionMethodKMS:ExportsOutputFnGetAttTestBucketWithEncryptionMethodKMSC063B900ArnD6399430",
+                      },
+                      "/*",
+                    ],
+                  ],
+                },
+              ],
+              "Sid": "DenyEveryoneElse",
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+      },
+      "Type": "AWS::S3::BucketPolicy",
+    },
     "CustomS3AutoDeleteObjectsCustomResourceProviderHandler9D90184F": Object {
       "DependsOn": Array [
         "CustomS3AutoDeleteObjectsCustomResourceProviderRole3B1BD092",
@@ -3941,6 +5345,708 @@ Object {
                           "AutoDeleteBucket93E032C1",
                           "Arn",
                         ],
+                      },
+                      "/*",
+                    ],
+                  ],
+                },
+              ],
+              "Sid": "DenyEveryoneElse",
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+      },
+      "Type": "AWS::S3::BucketPolicy",
+    },
+    "BucketPolicyWithAlternateEncryptionMethodPolicy0BA38F4B": Object {
+      "Properties": Object {
+        "Bucket": Object {
+          "Fn::ImportValue": "K9BucketPolicyAlternateEncryptionMethod:ExportsOutputRefTestBucketWithAlternateEncryptionMethodF9AD985C29FC2EE9",
+        },
+        "PolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": Array [
+                "s3:DeleteBucket",
+                "s3:DeleteBucketPolicy",
+                "s3:DeleteBucketWebsite",
+                "s3:ObjectOwnerOverrideToBucketOwner",
+                "s3:PutAccelerateConfiguration",
+                "s3:PutAnalyticsConfiguration",
+                "s3:PutBucketAcl",
+                "s3:PutBucketCORS",
+                "s3:PutBucketLogging",
+                "s3:PutBucketNotification",
+                "s3:PutBucketObjectLockConfiguration",
+                "s3:PutBucketPolicy",
+                "s3:PutBucketPublicAccessBlock",
+                "s3:PutBucketRequestPayment",
+                "s3:PutBucketTagging",
+                "s3:PutBucketVersioning",
+                "s3:PutBucketWebsite",
+                "s3:PutEncryptionConfiguration",
+                "s3:PutInventoryConfiguration",
+                "s3:PutLifecycleConfiguration",
+                "s3:PutMetricsConfiguration",
+                "s3:PutObjectAcl",
+                "s3:PutObjectLegalHold",
+                "s3:PutObjectRetention",
+                "s3:PutObjectVersionAcl",
+                "s3:PutReplicationConfiguration",
+              ],
+              "Condition": Object {
+                "ArnEquals": Object {
+                  "aws:PrincipalArn": Array [
+                    "arn:aws:iam::139710491120:user/ci",
+                  ],
+                },
+              },
+              "Effect": "Allow",
+              "Principal": "*",
+              "Resource": Array [
+                Object {
+                  "Fn::ImportValue": "K9BucketPolicyAlternateEncryptionMethod:ExportsOutputFnGetAttTestBucketWithAlternateEncryptionMethodF9AD985CArn042A2492",
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      Object {
+                        "Fn::ImportValue": "K9BucketPolicyAlternateEncryptionMethod:ExportsOutputFnGetAttTestBucketWithAlternateEncryptionMethodF9AD985CArn042A2492",
+                      },
+                      "/*",
+                    ],
+                  ],
+                },
+              ],
+              "Sid": "Allow Restricted administer-resource",
+            },
+            Object {
+              "Action": Array [
+                "s3:GetAccelerateConfiguration",
+                "s3:GetAnalyticsConfiguration",
+                "s3:GetBucketAcl",
+                "s3:GetBucketCORS",
+                "s3:GetBucketLocation",
+                "s3:GetBucketLogging",
+                "s3:GetBucketNotification",
+                "s3:GetBucketObjectLockConfiguration",
+                "s3:GetBucketOwnershipControls",
+                "s3:GetBucketPolicy",
+                "s3:GetBucketPolicyStatus",
+                "s3:GetBucketPublicAccessBlock",
+                "s3:GetBucketRequestPayment",
+                "s3:GetBucketTagging",
+                "s3:GetBucketVersioning",
+                "s3:GetBucketWebsite",
+                "s3:GetEncryptionConfiguration",
+                "s3:GetInventoryConfiguration",
+                "s3:GetLifecycleConfiguration",
+                "s3:GetMetricsConfiguration",
+                "s3:GetObjectAcl",
+                "s3:GetObjectLegalHold",
+                "s3:GetObjectRetention",
+                "s3:GetObjectTagging",
+                "s3:GetObjectVersionAcl",
+                "s3:GetObjectVersionTagging",
+                "s3:GetReplicationConfiguration",
+                "s3:ListBucketMultipartUploads",
+                "s3:ListBucketVersions",
+                "s3:ListMultipartUploadParts",
+              ],
+              "Condition": Object {
+                "ArnEquals": Object {
+                  "aws:PrincipalArn": Array [],
+                },
+              },
+              "Effect": "Allow",
+              "Principal": "*",
+              "Resource": Array [
+                Object {
+                  "Fn::ImportValue": "K9BucketPolicyAlternateEncryptionMethod:ExportsOutputFnGetAttTestBucketWithAlternateEncryptionMethodF9AD985CArn042A2492",
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      Object {
+                        "Fn::ImportValue": "K9BucketPolicyAlternateEncryptionMethod:ExportsOutputFnGetAttTestBucketWithAlternateEncryptionMethodF9AD985CArn042A2492",
+                      },
+                      "/*",
+                    ],
+                  ],
+                },
+              ],
+              "Sid": "Allow Restricted read-config",
+            },
+            Object {
+              "Action": Array [
+                "s3:GetObject",
+                "s3:GetObjectTorrent",
+                "s3:GetObjectVersion",
+                "s3:GetObjectVersionForReplication",
+                "s3:GetObjectVersionTorrent",
+                "s3:ListBucket",
+              ],
+              "Condition": Object {
+                "ArnEquals": Object {
+                  "aws:PrincipalArn": Array [],
+                },
+              },
+              "Effect": "Allow",
+              "Principal": "*",
+              "Resource": Array [
+                Object {
+                  "Fn::ImportValue": "K9BucketPolicyAlternateEncryptionMethod:ExportsOutputFnGetAttTestBucketWithAlternateEncryptionMethodF9AD985CArn042A2492",
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      Object {
+                        "Fn::ImportValue": "K9BucketPolicyAlternateEncryptionMethod:ExportsOutputFnGetAttTestBucketWithAlternateEncryptionMethodF9AD985CArn042A2492",
+                      },
+                      "/*",
+                    ],
+                  ],
+                },
+              ],
+              "Sid": "Allow Restricted read-data",
+            },
+            Object {
+              "Action": Array [
+                "s3:AbortMultipartUpload",
+                "s3:PutBucketTagging",
+                "s3:PutObject",
+                "s3:PutObjectTagging",
+                "s3:PutObjectVersionTagging",
+                "s3:ReplicateDelete",
+                "s3:ReplicateObject",
+                "s3:ReplicateTags",
+                "s3:RestoreObject",
+              ],
+              "Condition": Object {
+                "ArnEquals": Object {
+                  "aws:PrincipalArn": Array [],
+                },
+              },
+              "Effect": "Allow",
+              "Principal": "*",
+              "Resource": Array [
+                Object {
+                  "Fn::ImportValue": "K9BucketPolicyAlternateEncryptionMethod:ExportsOutputFnGetAttTestBucketWithAlternateEncryptionMethodF9AD985CArn042A2492",
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      Object {
+                        "Fn::ImportValue": "K9BucketPolicyAlternateEncryptionMethod:ExportsOutputFnGetAttTestBucketWithAlternateEncryptionMethodF9AD985CArn042A2492",
+                      },
+                      "/*",
+                    ],
+                  ],
+                },
+              ],
+              "Sid": "Allow Restricted write-data",
+            },
+            Object {
+              "Action": Array [
+                "s3:DeleteObject",
+                "s3:DeleteObjectTagging",
+                "s3:DeleteObjectVersion",
+                "s3:DeleteObjectVersionTagging",
+              ],
+              "Condition": Object {
+                "ArnEquals": Object {
+                  "aws:PrincipalArn": Array [],
+                },
+              },
+              "Effect": "Allow",
+              "Principal": "*",
+              "Resource": Array [
+                Object {
+                  "Fn::ImportValue": "K9BucketPolicyAlternateEncryptionMethod:ExportsOutputFnGetAttTestBucketWithAlternateEncryptionMethodF9AD985CArn042A2492",
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      Object {
+                        "Fn::ImportValue": "K9BucketPolicyAlternateEncryptionMethod:ExportsOutputFnGetAttTestBucketWithAlternateEncryptionMethodF9AD985CArn042A2492",
+                      },
+                      "/*",
+                    ],
+                  ],
+                },
+              ],
+              "Sid": "Allow Restricted delete-data",
+            },
+            Object {
+              "Action": "s3:*",
+              "Condition": Object {
+                "Bool": Object {
+                  "aws:SecureTransport": false,
+                },
+              },
+              "Effect": "Deny",
+              "Principal": "*",
+              "Resource": Array [
+                Object {
+                  "Fn::ImportValue": "K9BucketPolicyAlternateEncryptionMethod:ExportsOutputFnGetAttTestBucketWithAlternateEncryptionMethodF9AD985CArn042A2492",
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      Object {
+                        "Fn::ImportValue": "K9BucketPolicyAlternateEncryptionMethod:ExportsOutputFnGetAttTestBucketWithAlternateEncryptionMethodF9AD985CArn042A2492",
+                      },
+                      "/*",
+                    ],
+                  ],
+                },
+              ],
+              "Sid": "DenyInsecureCommunications",
+            },
+            Object {
+              "Action": Array [
+                "s3:PutObject",
+                "s3:ReplicateObject",
+              ],
+              "Condition": Object {
+                "Null": Object {
+                  "s3:x-amz-server-side-encryption": true,
+                },
+              },
+              "Effect": "Deny",
+              "Principal": "*",
+              "Resource": Array [
+                Object {
+                  "Fn::ImportValue": "K9BucketPolicyAlternateEncryptionMethod:ExportsOutputFnGetAttTestBucketWithAlternateEncryptionMethodF9AD985CArn042A2492",
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      Object {
+                        "Fn::ImportValue": "K9BucketPolicyAlternateEncryptionMethod:ExportsOutputFnGetAttTestBucketWithAlternateEncryptionMethodF9AD985CArn042A2492",
+                      },
+                      "/*",
+                    ],
+                  ],
+                },
+              ],
+              "Sid": "DenyUnencryptedStorage",
+            },
+            Object {
+              "Action": Array [
+                "s3:PutObject",
+                "s3:ReplicateObject",
+              ],
+              "Condition": Object {
+                "StringNotEquals": Object {
+                  "s3:x-amz-server-side-encryption": "AES-256",
+                },
+              },
+              "Effect": "Deny",
+              "Principal": "*",
+              "Resource": Array [
+                Object {
+                  "Fn::ImportValue": "K9BucketPolicyAlternateEncryptionMethod:ExportsOutputFnGetAttTestBucketWithAlternateEncryptionMethodF9AD985CArn042A2492",
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      Object {
+                        "Fn::ImportValue": "K9BucketPolicyAlternateEncryptionMethod:ExportsOutputFnGetAttTestBucketWithAlternateEncryptionMethodF9AD985CArn042A2492",
+                      },
+                      "/*",
+                    ],
+                  ],
+                },
+              ],
+              "Sid": "DenyUnexpectedEncryptionMethod",
+            },
+            Object {
+              "Action": "s3:*",
+              "Condition": Object {
+                "ArnNotEquals": Object {
+                  "aws:PrincipalArn": Array [
+                    "arn:aws:iam::139710491120:user/ci",
+                  ],
+                },
+              },
+              "Effect": "Deny",
+              "Principal": Object {
+                "AWS": Array [
+                  "*",
+                  "*",
+                ],
+              },
+              "Resource": Array [
+                Object {
+                  "Fn::ImportValue": "K9BucketPolicyAlternateEncryptionMethod:ExportsOutputFnGetAttTestBucketWithAlternateEncryptionMethodF9AD985CArn042A2492",
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      Object {
+                        "Fn::ImportValue": "K9BucketPolicyAlternateEncryptionMethod:ExportsOutputFnGetAttTestBucketWithAlternateEncryptionMethodF9AD985CArn042A2492",
+                      },
+                      "/*",
+                    ],
+                  ],
+                },
+              ],
+              "Sid": "DenyEveryoneElse",
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+      },
+      "Type": "AWS::S3::BucketPolicy",
+    },
+    "BucketPolicyWithEncryptionMethodKMSPolicy8EA8A63A": Object {
+      "Properties": Object {
+        "Bucket": Object {
+          "Fn::ImportValue": "K9BucketPolicyWithEncryptionMethodKMS:ExportsOutputRefTestBucketWithEncryptionMethodKMSC063B9007C32753A",
+        },
+        "PolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": Array [
+                "s3:DeleteBucket",
+                "s3:DeleteBucketPolicy",
+                "s3:DeleteBucketWebsite",
+                "s3:ObjectOwnerOverrideToBucketOwner",
+                "s3:PutAccelerateConfiguration",
+                "s3:PutAnalyticsConfiguration",
+                "s3:PutBucketAcl",
+                "s3:PutBucketCORS",
+                "s3:PutBucketLogging",
+                "s3:PutBucketNotification",
+                "s3:PutBucketObjectLockConfiguration",
+                "s3:PutBucketPolicy",
+                "s3:PutBucketPublicAccessBlock",
+                "s3:PutBucketRequestPayment",
+                "s3:PutBucketTagging",
+                "s3:PutBucketVersioning",
+                "s3:PutBucketWebsite",
+                "s3:PutEncryptionConfiguration",
+                "s3:PutInventoryConfiguration",
+                "s3:PutLifecycleConfiguration",
+                "s3:PutMetricsConfiguration",
+                "s3:PutObjectAcl",
+                "s3:PutObjectLegalHold",
+                "s3:PutObjectRetention",
+                "s3:PutObjectVersionAcl",
+                "s3:PutReplicationConfiguration",
+              ],
+              "Condition": Object {
+                "ArnEquals": Object {
+                  "aws:PrincipalArn": Array [
+                    "arn:aws:iam::139710491120:user/ci",
+                  ],
+                },
+              },
+              "Effect": "Allow",
+              "Principal": "*",
+              "Resource": Array [
+                Object {
+                  "Fn::ImportValue": "K9BucketPolicyWithEncryptionMethodKMS:ExportsOutputFnGetAttTestBucketWithEncryptionMethodKMSC063B900ArnD6399430",
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      Object {
+                        "Fn::ImportValue": "K9BucketPolicyWithEncryptionMethodKMS:ExportsOutputFnGetAttTestBucketWithEncryptionMethodKMSC063B900ArnD6399430",
+                      },
+                      "/*",
+                    ],
+                  ],
+                },
+              ],
+              "Sid": "Allow Restricted administer-resource",
+            },
+            Object {
+              "Action": Array [
+                "s3:GetAccelerateConfiguration",
+                "s3:GetAnalyticsConfiguration",
+                "s3:GetBucketAcl",
+                "s3:GetBucketCORS",
+                "s3:GetBucketLocation",
+                "s3:GetBucketLogging",
+                "s3:GetBucketNotification",
+                "s3:GetBucketObjectLockConfiguration",
+                "s3:GetBucketOwnershipControls",
+                "s3:GetBucketPolicy",
+                "s3:GetBucketPolicyStatus",
+                "s3:GetBucketPublicAccessBlock",
+                "s3:GetBucketRequestPayment",
+                "s3:GetBucketTagging",
+                "s3:GetBucketVersioning",
+                "s3:GetBucketWebsite",
+                "s3:GetEncryptionConfiguration",
+                "s3:GetInventoryConfiguration",
+                "s3:GetLifecycleConfiguration",
+                "s3:GetMetricsConfiguration",
+                "s3:GetObjectAcl",
+                "s3:GetObjectLegalHold",
+                "s3:GetObjectRetention",
+                "s3:GetObjectTagging",
+                "s3:GetObjectVersionAcl",
+                "s3:GetObjectVersionTagging",
+                "s3:GetReplicationConfiguration",
+                "s3:ListBucketMultipartUploads",
+                "s3:ListBucketVersions",
+                "s3:ListMultipartUploadParts",
+              ],
+              "Condition": Object {
+                "ArnEquals": Object {
+                  "aws:PrincipalArn": Array [],
+                },
+              },
+              "Effect": "Allow",
+              "Principal": "*",
+              "Resource": Array [
+                Object {
+                  "Fn::ImportValue": "K9BucketPolicyWithEncryptionMethodKMS:ExportsOutputFnGetAttTestBucketWithEncryptionMethodKMSC063B900ArnD6399430",
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      Object {
+                        "Fn::ImportValue": "K9BucketPolicyWithEncryptionMethodKMS:ExportsOutputFnGetAttTestBucketWithEncryptionMethodKMSC063B900ArnD6399430",
+                      },
+                      "/*",
+                    ],
+                  ],
+                },
+              ],
+              "Sid": "Allow Restricted read-config",
+            },
+            Object {
+              "Action": Array [
+                "s3:GetObject",
+                "s3:GetObjectTorrent",
+                "s3:GetObjectVersion",
+                "s3:GetObjectVersionForReplication",
+                "s3:GetObjectVersionTorrent",
+                "s3:ListBucket",
+              ],
+              "Condition": Object {
+                "ArnEquals": Object {
+                  "aws:PrincipalArn": Array [],
+                },
+              },
+              "Effect": "Allow",
+              "Principal": "*",
+              "Resource": Array [
+                Object {
+                  "Fn::ImportValue": "K9BucketPolicyWithEncryptionMethodKMS:ExportsOutputFnGetAttTestBucketWithEncryptionMethodKMSC063B900ArnD6399430",
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      Object {
+                        "Fn::ImportValue": "K9BucketPolicyWithEncryptionMethodKMS:ExportsOutputFnGetAttTestBucketWithEncryptionMethodKMSC063B900ArnD6399430",
+                      },
+                      "/*",
+                    ],
+                  ],
+                },
+              ],
+              "Sid": "Allow Restricted read-data",
+            },
+            Object {
+              "Action": Array [
+                "s3:AbortMultipartUpload",
+                "s3:PutBucketTagging",
+                "s3:PutObject",
+                "s3:PutObjectTagging",
+                "s3:PutObjectVersionTagging",
+                "s3:ReplicateDelete",
+                "s3:ReplicateObject",
+                "s3:ReplicateTags",
+                "s3:RestoreObject",
+              ],
+              "Condition": Object {
+                "ArnEquals": Object {
+                  "aws:PrincipalArn": Array [],
+                },
+              },
+              "Effect": "Allow",
+              "Principal": "*",
+              "Resource": Array [
+                Object {
+                  "Fn::ImportValue": "K9BucketPolicyWithEncryptionMethodKMS:ExportsOutputFnGetAttTestBucketWithEncryptionMethodKMSC063B900ArnD6399430",
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      Object {
+                        "Fn::ImportValue": "K9BucketPolicyWithEncryptionMethodKMS:ExportsOutputFnGetAttTestBucketWithEncryptionMethodKMSC063B900ArnD6399430",
+                      },
+                      "/*",
+                    ],
+                  ],
+                },
+              ],
+              "Sid": "Allow Restricted write-data",
+            },
+            Object {
+              "Action": Array [
+                "s3:DeleteObject",
+                "s3:DeleteObjectTagging",
+                "s3:DeleteObjectVersion",
+                "s3:DeleteObjectVersionTagging",
+              ],
+              "Condition": Object {
+                "ArnEquals": Object {
+                  "aws:PrincipalArn": Array [],
+                },
+              },
+              "Effect": "Allow",
+              "Principal": "*",
+              "Resource": Array [
+                Object {
+                  "Fn::ImportValue": "K9BucketPolicyWithEncryptionMethodKMS:ExportsOutputFnGetAttTestBucketWithEncryptionMethodKMSC063B900ArnD6399430",
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      Object {
+                        "Fn::ImportValue": "K9BucketPolicyWithEncryptionMethodKMS:ExportsOutputFnGetAttTestBucketWithEncryptionMethodKMSC063B900ArnD6399430",
+                      },
+                      "/*",
+                    ],
+                  ],
+                },
+              ],
+              "Sid": "Allow Restricted delete-data",
+            },
+            Object {
+              "Action": "s3:*",
+              "Condition": Object {
+                "Bool": Object {
+                  "aws:SecureTransport": false,
+                },
+              },
+              "Effect": "Deny",
+              "Principal": "*",
+              "Resource": Array [
+                Object {
+                  "Fn::ImportValue": "K9BucketPolicyWithEncryptionMethodKMS:ExportsOutputFnGetAttTestBucketWithEncryptionMethodKMSC063B900ArnD6399430",
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      Object {
+                        "Fn::ImportValue": "K9BucketPolicyWithEncryptionMethodKMS:ExportsOutputFnGetAttTestBucketWithEncryptionMethodKMSC063B900ArnD6399430",
+                      },
+                      "/*",
+                    ],
+                  ],
+                },
+              ],
+              "Sid": "DenyInsecureCommunications",
+            },
+            Object {
+              "Action": Array [
+                "s3:PutObject",
+                "s3:ReplicateObject",
+              ],
+              "Condition": Object {
+                "Null": Object {
+                  "s3:x-amz-server-side-encryption": true,
+                },
+              },
+              "Effect": "Deny",
+              "Principal": "*",
+              "Resource": Array [
+                Object {
+                  "Fn::ImportValue": "K9BucketPolicyWithEncryptionMethodKMS:ExportsOutputFnGetAttTestBucketWithEncryptionMethodKMSC063B900ArnD6399430",
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      Object {
+                        "Fn::ImportValue": "K9BucketPolicyWithEncryptionMethodKMS:ExportsOutputFnGetAttTestBucketWithEncryptionMethodKMSC063B900ArnD6399430",
+                      },
+                      "/*",
+                    ],
+                  ],
+                },
+              ],
+              "Sid": "DenyUnencryptedStorage",
+            },
+            Object {
+              "Action": Array [
+                "s3:PutObject",
+                "s3:ReplicateObject",
+              ],
+              "Condition": Object {
+                "StringNotEquals": Object {
+                  "s3:x-amz-server-side-encryption": "aws:kms",
+                },
+              },
+              "Effect": "Deny",
+              "Principal": "*",
+              "Resource": Array [
+                Object {
+                  "Fn::ImportValue": "K9BucketPolicyWithEncryptionMethodKMS:ExportsOutputFnGetAttTestBucketWithEncryptionMethodKMSC063B900ArnD6399430",
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      Object {
+                        "Fn::ImportValue": "K9BucketPolicyWithEncryptionMethodKMS:ExportsOutputFnGetAttTestBucketWithEncryptionMethodKMSC063B900ArnD6399430",
+                      },
+                      "/*",
+                    ],
+                  ],
+                },
+              ],
+              "Sid": "DenyUnexpectedEncryptionMethod",
+            },
+            Object {
+              "Action": "s3:*",
+              "Condition": Object {
+                "ArnNotEquals": Object {
+                  "aws:PrincipalArn": Array [
+                    "arn:aws:iam::139710491120:user/ci",
+                  ],
+                },
+              },
+              "Effect": "Deny",
+              "Principal": Object {
+                "AWS": Array [
+                  "*",
+                  "*",
+                ],
+              },
+              "Resource": Array [
+                Object {
+                  "Fn::ImportValue": "K9BucketPolicyWithEncryptionMethodKMS:ExportsOutputFnGetAttTestBucketWithEncryptionMethodKMSC063B900ArnD6399430",
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      Object {
+                        "Fn::ImportValue": "K9BucketPolicyWithEncryptionMethodKMS:ExportsOutputFnGetAttTestBucketWithEncryptionMethodKMSC063B900ArnD6399430",
                       },
                       "/*",
                     ],

--- a/test/__snapshots__/k9.test.ts.snap
+++ b/test/__snapshots__/k9.test.ts.snap
@@ -368,7 +368,7 @@ Object {
                   ],
                 },
               ],
-              "Sid": "DenyStorageWithoutKMSEncryption",
+              "Sid": "DenyUnexpectedEncryptionMethod",
             },
             Object {
               "Action": "s3:*",
@@ -793,7 +793,7 @@ Object {
                   ],
                 },
               ],
-              "Sid": "DenyStorageWithoutKMSEncryption",
+              "Sid": "DenyUnexpectedEncryptionMethod",
             },
             Object {
               "Action": "s3:*",
@@ -1292,7 +1292,7 @@ Object {
                   ],
                 },
               ],
-              "Sid": "DenyStorageWithoutKMSEncryption",
+              "Sid": "DenyUnexpectedEncryptionMethod",
             },
             Object {
               "Action": "s3:*",
@@ -1801,7 +1801,7 @@ Object {
                   ],
                 },
               ],
-              "Sid": "DenyStorageWithoutKMSEncryption",
+              "Sid": "DenyUnexpectedEncryptionMethod",
             },
             Object {
               "Action": "s3:*",
@@ -2718,7 +2718,7 @@ Object {
                   ],
                 },
               ],
-              "Sid": "DenyStorageWithoutKMSEncryption",
+              "Sid": "DenyUnexpectedEncryptionMethod",
             },
             Object {
               "Action": "s3:*",
@@ -3227,7 +3227,7 @@ Object {
                   ],
                 },
               ],
-              "Sid": "DenyStorageWithoutKMSEncryption",
+              "Sid": "DenyUnexpectedEncryptionMethod",
             },
             Object {
               "Action": "s3:*",
@@ -3900,7 +3900,7 @@ Object {
                   ],
                 },
               ],
-              "Sid": "DenyStorageWithoutKMSEncryption",
+              "Sid": "DenyUnexpectedEncryptionMethod",
             },
             Object {
               "Action": "s3:*",
@@ -4409,7 +4409,7 @@ Object {
                   ],
                 },
               ],
-              "Sid": "DenyStorageWithoutKMSEncryption",
+              "Sid": "DenyUnexpectedEncryptionMethod",
             },
             Object {
               "Action": "s3:*",

--- a/test/k9.test.ts
+++ b/test/k9.test.ts
@@ -4,7 +4,7 @@ import {RemovalPolicy} from '@aws-cdk/core';
 import * as kms from '@aws-cdk/aws-kms';
 import * as s3 from '@aws-cdk/aws-s3';
 import {AccessCapability, AccessSpec} from '../lib/k9policy';
-import {K9BucketPolicyProps} from "../lib/s3";
+import {K9BucketPolicyProps, SID_DENY_UNEXPECTED_ENCRYPTION_METHOD} from "../lib/s3";
 import {K9KeyPolicyProps, SID_ALLOW_ROOT_AND_IDENTITY_POLICIES, SID_DENY_EVERYONE_ELSE} from "../lib/kms";
 import * as k9 from "../lib";
 import {AddToResourcePolicyResult} from "@aws-cdk/aws-iam";
@@ -60,10 +60,20 @@ test('K9BucketPolicy', () => {
     let addToResourcePolicyResults = k9.s3.grantAccessViaResourcePolicy(stack, "S3Bucket", k9BucketPolicyProps);
     expect(bucket.policy).toBeDefined();
 
-    console.log("bucket.policy?.document: " + stringifyPolicy(bucket.policy?.document));
+    let policyStr = stringifyPolicy(bucket.policy?.document);
+    console.log("bucket.policy?.document: " + policyStr);
     expect(bucket.policy?.document).toBeDefined();
 
     assertK9StatementsAddedToS3ResourcePolicy(addToResourcePolicyResults);
+    let policyObj = JSON.parse(policyStr)
+    let actualPolicyStatements = policyObj['Statement'];
+    expect(actualPolicyStatements).toBeDefined();
+
+    for (let stmt of actualPolicyStatements) {
+        if(SID_DENY_UNEXPECTED_ENCRYPTION_METHOD == stmt.Sid){
+            expect(stmt.Condition['StringNotEquals']['s3:x-amz-server-side-encryption']).toEqual('aws:kms');
+        }
+    }
 
     expectCDK(stack).to(haveResource("AWS::S3::Bucket"));
     expectCDK(stack).to(haveResource("AWS::S3::BucketPolicy"));

--- a/test/k9.test.ts
+++ b/test/k9.test.ts
@@ -3,6 +3,7 @@ import * as cdk from '@aws-cdk/core';
 import {RemovalPolicy} from '@aws-cdk/core';
 import * as kms from '@aws-cdk/aws-kms';
 import * as s3 from '@aws-cdk/aws-s3';
+import {BucketEncryption} from '@aws-cdk/aws-s3';
 import {AccessCapability, AccessSpec} from '../lib/k9policy';
 import {K9BucketPolicyProps, SID_DENY_UNEXPECTED_ENCRYPTION_METHOD} from "../lib/s3";
 import {K9KeyPolicyProps, SID_ALLOW_ROOT_AND_IDENTITY_POLICIES, SID_DENY_EVERYONE_ELSE} from "../lib/kms";
@@ -32,7 +33,7 @@ const app = new cdk.App();
 
 const stack = new cdk.Stack(app, 'K9PolicyTest');
 
-test('K9BucketPolicy', () => {
+test('K9BucketPolicy - typical usage', () => {
 
     const bucket = new s3.Bucket(stack, 'TestBucket', {});
 
@@ -78,6 +79,74 @@ test('K9BucketPolicy', () => {
     expectCDK(stack).to(haveResource("AWS::S3::Bucket"));
     expectCDK(stack).to(haveResource("AWS::S3::BucketPolicy"));
     expect(SynthUtils.toCloudFormation(stack)).toMatchSnapshot();
+});
+
+test('K9BucketPolicy - specify encryption method - KMS', () => {
+    const localstack = new cdk.Stack(app, 'K9BucketPolicyWithEncryptionMethodKMS');
+    const bucket = new s3.Bucket(localstack, 'TestBucketWithEncryptionMethodKMS', {});
+
+    const k9BucketPolicyProps: K9BucketPolicyProps = {
+        bucket: bucket,
+        k9DesiredAccess: new Array<AccessSpec>(
+            {
+                accessCapabilities: AccessCapability.AdministerResource,
+                allowPrincipalArns: administerResourceArns,
+            }
+        ),
+        encryption: BucketEncryption.KMS,
+    };
+    let addToResourcePolicyResults = k9.s3.grantAccessViaResourcePolicy(stack, "BucketPolicyWithEncryptionMethodKMS", k9BucketPolicyProps);
+    expect(bucket.policy).toBeDefined();
+
+    let policyStr = stringifyPolicy(bucket.policy?.document);
+    console.log("bucket.policy?.document: " + policyStr);
+    expect(bucket.policy?.document).toBeDefined();
+
+    assertK9StatementsAddedToS3ResourcePolicy(addToResourcePolicyResults);
+    let policyObj = JSON.parse(policyStr)
+    let actualPolicyStatements = policyObj['Statement'];
+    expect(actualPolicyStatements).toBeDefined();
+
+    for (let stmt of actualPolicyStatements) {
+        if(SID_DENY_UNEXPECTED_ENCRYPTION_METHOD == stmt.Sid){
+            expect(stmt.Condition['StringNotEquals']['s3:x-amz-server-side-encryption']).toEqual('aws:kms');
+        }
+    }
+
+})
+
+test('K9BucketPolicy - specify encryption method - S3_MANAGED', () => {
+    const localstack = new cdk.Stack(app, 'K9BucketPolicyAlternateEncryptionMethod');
+    const bucket = new s3.Bucket(localstack, 'TestBucketWithAlternateEncryptionMethod', {});
+
+    const k9BucketPolicyProps: K9BucketPolicyProps = {
+        bucket: bucket,
+        k9DesiredAccess: new Array<AccessSpec>(
+            {
+                accessCapabilities: AccessCapability.AdministerResource,
+                allowPrincipalArns: administerResourceArns,
+            }
+        ),
+        encryption: BucketEncryption.S3_MANAGED,
+    };
+    let addToResourcePolicyResults = k9.s3.grantAccessViaResourcePolicy(stack, "BucketPolicyWithAlternateEncryptionMethod", k9BucketPolicyProps);
+    expect(bucket.policy).toBeDefined();
+
+    let policyStr = stringifyPolicy(bucket.policy?.document);
+    console.log("bucket.policy?.document: " + policyStr);
+    expect(bucket.policy?.document).toBeDefined();
+
+    assertK9StatementsAddedToS3ResourcePolicy(addToResourcePolicyResults);
+    let policyObj = JSON.parse(policyStr)
+    let actualPolicyStatements = policyObj['Statement'];
+    expect(actualPolicyStatements).toBeDefined();
+
+    for (let stmt of actualPolicyStatements) {
+        if(SID_DENY_UNEXPECTED_ENCRYPTION_METHOD == stmt.Sid){
+            expect(stmt.Condition['StringNotEquals']['s3:x-amz-server-side-encryption']).toEqual('AES-256');
+        }
+    }
+
 });
 
 test('K9BucketPolicy - AccessSpec with set of capabilities', () => {


### PR DESCRIPTION
Support uploads using presigned urls to buckets using S3 managed encryption.

This allows customers to generate presigned urls without requiring clients to specify the KMS key id, protecting the anonymity of that key.