### PR TITLE
feat: Allow AWS services to access protected S3 buckets & KMS keys (scalable)

### DIFF
--- a/bin/k9-cdk.ts
+++ b/bin/k9-cdk.ts
@@ -2,6 +2,8 @@
 
 import * as cdk from "aws-cdk-lib";
 import {RemovalPolicy, Tags} from "aws-cdk-lib";
+// import * as cloudfront from "aws-cdk-lib/aws-cloudfront";
+// import * as cforigins from "aws-cdk-lib/aws-cloudfront-origins";
 import * as kms from "aws-cdk-lib/aws-kms";
 import * as s3 from "aws-cdk-lib/aws-s3";
 import {BlockPublicAccess, BucketEncryption} from "aws-cdk-lib/aws-s3";
@@ -26,6 +28,7 @@ const readConfigArns = administerResourceArns.concat(
 const readWriteDataArns = [
     "arn:aws:iam::123456789012:role/app-backend",
     "arn:aws:iam::139710491120:role/k9-dev-appeng",
+    "arn:aws:sts::139710491120:assumed-role/k9-dev-appeng/console"
 ];
 
 const readDataArns = [
@@ -132,6 +135,60 @@ const key = new kms.Key(stack, 'KMSKey', {
     policy: keyPolicy,
 });
 
-for(let construct of [bucket, websiteBucket, autoDeleteBucket, key]){
+// Created test distribution manually because I haven't fully sorted through
+// https://github.com/aws/aws-cdk/issues/21771
+//
+// let cloudfrontDistribution = new cloudfront.Distribution(stack, 'oac-bucket-dist', {
+//     comment: 'k9-cdk integration test distribution for CloudFront OAC',
+//     defaultBehavior: {
+//         origin: new cforigins.S3Origin(cloudfrontOACBucket, {
+//
+//         }),
+//     },
+// });
+let cloudfrontDistributionId = 'E1OHGXOERP1X0D'
+let cloudfrontDistributionArn = `arn:aws:cloudfront::${stack.account}:distribution/${cloudfrontDistributionId}`
+// let cloudfrontDistributionArn = `arn:aws:cloudfront::${stack.account}:distribution/${cloudfrontDistribution.distributionId}`
+
+const cloudfrontOACk9KeyPolicyProps: k9.kms.K9KeyPolicyProps = {
+    k9DesiredAccess: k9BucketPolicyProps.k9DesiredAccess,
+    trustAccountIdentities: false,
+    awsServiceAccessGenerators: new Array<k9.k9policy.IAWSServiceAccessGenerator>(
+        new k9.kms.CloudFrontOACReadAccessGenerator(cloudfrontDistributionArn),
+    )
+};
+const cloudfrontOACKeyPolicy = k9.kms.makeKeyPolicy(cloudfrontOACk9KeyPolicyProps);
+
+const cloudfrontOACKey = new kms.Key(stack, 'CloudFrontOACKMSKey', {
+    alias: 'k9-cdk-v2-cloudfront-oac-test',
+    policy: cloudfrontOACKeyPolicy,
+});
+
+const cloudfrontOACBucket = new s3.Bucket(stack, 'CloudFrontOACBucket', {
+    bucketName: 'k9-cdk-v2-cloudfront-oac-test',
+    removalPolicy: RemovalPolicy.DESTROY,
+    encryption: BucketEncryption.KMS,
+    encryptionKey: cloudfrontOACKey
+});
+
+const cloudfrontOACBucketPolicyProps: k9.s3.K9BucketPolicyProps = {
+    bucket: cloudfrontOACBucket,
+    k9DesiredAccess: k9BucketPolicyProps.k9DesiredAccess.concat([]),
+    encryption: BucketEncryption.KMS_MANAGED,
+    awsServiceAccessGenerators: new Array<k9.k9policy.IAWSServiceAccessGenerator>(
+      new k9.s3.CloudFrontOACReadAccessGenerator(cloudfrontOACBucket, cloudfrontDistributionArn),
+    )
+};
+
+k9.s3.grantAccessViaResourcePolicy(stack, "CloudFrontOACBucket", cloudfrontOACBucketPolicyProps);
+
+for (let construct of [bucket,
+    websiteBucket,
+    autoDeleteBucket,
+    key,
+    // cloudfrontDistribution,
+    cloudfrontOACBucket,
+    cloudfrontOACKey,
+]) {
     Tags.of(construct).add('k9security:analysis', 'include');
 }

--- a/bin/k9-cdk.ts
+++ b/bin/k9-cdk.ts
@@ -4,7 +4,7 @@ import * as cdk from "aws-cdk-lib";
 import {RemovalPolicy, Tags} from "aws-cdk-lib";
 import * as kms from "aws-cdk-lib/aws-kms";
 import * as s3 from "aws-cdk-lib/aws-s3";
-import {BucketEncryption} from "aws-cdk-lib/aws-s3";
+import {BlockPublicAccess, BucketEncryption} from "aws-cdk-lib/aws-s3";
 
 import * as k9 from "../lib";
 
@@ -12,9 +12,7 @@ const administerResourceArns = [
     // for development
     "arn:aws:iam::139710491120:user/ci",
     "arn:aws:iam::139710491120:user/skuenzli",
-    "arn:aws:sts::139710491120:federated-user/skuenzli",
     "arn:aws:iam::139710491120:role/k9-dev-appeng",
-    "arn:aws:sts::139710491120:assumed-role/k9-dev-appeng/console",
     "arn:aws:iam::139710491120:role/cdk-hnb659fds-cfn-exec-role-139710491120-us-east-1"
 ];
 
@@ -28,7 +26,6 @@ const readConfigArns = administerResourceArns.concat(
 const readWriteDataArns = [
     "arn:aws:iam::123456789012:role/app-backend",
     "arn:aws:iam::139710491120:role/k9-dev-appeng",
-    "arn:aws:sts::139710491120:assumed-role/k9-dev-appeng/console",
 ];
 
 const readDataArns = [
@@ -78,6 +75,9 @@ const websiteBucket = new s3.Bucket(stack, 'WebsiteBucket', {
     bucketName: 'k9-cdk-v2-public-website-test',
     removalPolicy: RemovalPolicy.DESTROY,
     encryption: BucketEncryption.S3_MANAGED,
+    blockPublicAccess: new BlockPublicAccess({
+        blockPublicPolicy: false
+    })
 });
 
 const websiteK9BucketPolicyProps: k9.s3.K9BucketPolicyProps = {

--- a/bin/k9-cdk.ts
+++ b/bin/k9-cdk.ts
@@ -131,7 +131,7 @@ const keyPolicy = k9.kms.makeKeyPolicy(k9KeyPolicyProps);
 
 // Set CDK preference @aws-cdk/aws-kms:defaultKeyPolicies to true in cdk.json
 const key = new kms.Key(stack, 'KMSKey', {
-    alias: 'k9-cdk-integration-test',
+    alias: 'k9-cdk-v2-integration-test',
     policy: keyPolicy,
 });
 

--- a/src/k9policy.ts
+++ b/src/k9policy.ts
@@ -43,9 +43,21 @@ export interface IAccessSpec {
   test?: ArnConditionTest;
 }
 
+/**
+ * `IAWSServiceAccessGenerator` defines an interface that the k9 policy generators use to grant an AWS service
+ * access to a protected resource.
+ */
 export interface IAWSServiceAccessGenerator {
+  /**
+   * Make an array of PolicyStatement objects that allow an AWS service, e.g. CloudFront, to access to the
+   * protected AWS resource.
+   */
   makeAllowStatements(): Array<PolicyStatement>;
 
+  /**
+   * Make a Conditions object that creates an exception for an AWS service in a protected resource's `DenyEveryoneElse`
+   * statement.
+   */
   makeConditionsToExceptFromDenyEveryoneElse(): Conditions;
 }
 

--- a/src/k9policy.ts
+++ b/src/k9policy.ts
@@ -4,7 +4,7 @@ import {
   Conditions,
   Effect,
   PolicyStatement,
-  PolicyStatementProps
+  PolicyStatementProps,
 } from 'aws-cdk-lib/aws-iam';
 
 export type ArnEqualsTest = 'ArnEquals'

--- a/src/k9policy.ts
+++ b/src/k9policy.ts
@@ -43,7 +43,7 @@ export interface IAccessSpec {
   test?: ArnConditionTest;
 }
 
-export interface IServiceAccessSpec {
+export interface IAWSServiceAccessGenerator {
   makeAllowStatements(): Array<PolicyStatement>;
 
   makeConditionsToExceptFromDenyEveryoneElse(): Conditions;

--- a/src/k9policy.ts
+++ b/src/k9policy.ts
@@ -1,4 +1,11 @@
-import { AnyPrincipal, ArnPrincipal, Effect, PolicyStatement, PolicyStatementProps } from 'aws-cdk-lib/aws-iam';
+import {
+  AnyPrincipal,
+  ArnPrincipal,
+  Conditions,
+  Effect,
+  PolicyStatement,
+  PolicyStatementProps
+} from 'aws-cdk-lib/aws-iam';
 
 export type ArnEqualsTest = 'ArnEquals'
 
@@ -34,6 +41,12 @@ export interface IAccessSpec {
   accessCapabilities: Array<AccessCapability> | AccessCapability;
   allowPrincipalArns: Array<string>;
   test?: ArnConditionTest;
+}
+
+export interface IServiceAccessSpec {
+  servicePrincipal: string;
+  allowStatements: Array<PolicyStatement>;
+  denyEveryoneElseConditions: Conditions;
 }
 
 export class K9PolicyFactory {

--- a/src/k9policy.ts
+++ b/src/k9policy.ts
@@ -44,9 +44,9 @@ export interface IAccessSpec {
 }
 
 export interface IServiceAccessSpec {
-  servicePrincipal: string;
-  allowStatements: Array<PolicyStatement>;
-  denyEveryoneElseConditions: Conditions;
+  makeAllowStatements(): Array<PolicyStatement>;
+
+  makeConditionsToExceptFromDenyEveryoneElse(): Conditions;
 }
 
 export class K9PolicyFactory {

--- a/src/kms.ts
+++ b/src/kms.ts
@@ -18,7 +18,7 @@ let SUPPORTED_CAPABILITIES = new Array<AccessCapability>(
 export const SID_ALLOW_ROOT_AND_IDENTITY_POLICIES = 'Allow Root User to Administer Key And Identity Policies';
 export const SID_DENY_EVERYONE_ELSE = 'DenyEveryoneElse';
 
-function canPrincipalsCanManageKey(accessSpecsByCapability: Map<AccessCapability, IAccessSpec>) {
+function canPrincipalsManageKey(accessSpecsByCapability: Map<AccessCapability, IAccessSpec>) {
   let adminSpec = accessSpecsByCapability.get(AccessCapability.ADMINISTER_RESOURCE);
   let readConfigSpec = accessSpecsByCapability.get(AccessCapability.READ_CONFIG);
 
@@ -46,7 +46,7 @@ export function makeKeyPolicy(props: K9KeyPolicyProps): PolicyDocument {
     accessSpecsByCapability.set(getAccessCapabilityFromValue(capabilityStr), accessSpec);
   }
 
-  if (!canPrincipalsCanManageKey(accessSpecsByCapability)) {
+  if (!canPrincipalsManageKey(accessSpecsByCapability)) {
     throw Error('At least one principal must be able to administer and read-config for keys' +
             ' so encrypted data remains accessible; found:\n' +
             `administer-resource: '${accessSpecsByCapability.get(AccessCapability.ADMINISTER_RESOURCE)?.allowPrincipalArns}'\n` +

--- a/src/kms.ts
+++ b/src/kms.ts
@@ -1,10 +1,30 @@
 import * as iam from 'aws-cdk-lib/aws-iam';
-import { AccountRootPrincipal, Effect, PolicyDocument, PolicyStatement } from 'aws-cdk-lib/aws-iam';
-import { AccessCapability, getAccessCapabilityFromValue, IAccessSpec, K9PolicyFactory } from './k9policy';
+import {
+  AccountRootPrincipal, AnyPrincipal,
+  Conditions,
+  Effect,
+  PolicyDocument,
+  PolicyStatement,
+  ServicePrincipal,
+} from 'aws-cdk-lib/aws-iam';
+import {
+  AccessCapability,
+  getAccessCapabilityFromValue,
+  IAccessSpec,
+  IAWSServiceAccessGenerator,
+  K9PolicyFactory,
+} from './k9policy';
 
 export interface K9KeyPolicyProps {
   readonly k9DesiredAccess: Array<IAccessSpec>;
   readonly trustAccountIdentities?: boolean;
+  /**
+   * An (optional) array of IAWSServiceAccessGenerator instances which will generate statements to allow access to the
+   * key by an AWS service like CloudFront or Kinesis.
+   *
+   * @default undefined
+   */
+  readonly awsServiceAccessGenerators?: Array<IAWSServiceAccessGenerator>;
 }
 
 let SUPPORTED_CAPABILITIES = new Array<AccessCapability>(
@@ -17,6 +37,58 @@ let SUPPORTED_CAPABILITIES = new Array<AccessCapability>(
 
 export const SID_ALLOW_ROOT_AND_IDENTITY_POLICIES = 'Allow Root User to Administer Key And Identity Policies';
 export const SID_DENY_EVERYONE_ELSE = 'DenyEveryoneElse';
+
+/**
+ * Generate key policy statements to enable the CloudFront service to read encrypted S3 bucket object data (only)
+ * from within a <a href="https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/private-content-restricting-access-to-s3.html#sse-kms">CloudFront OAC integration</a>.
+ */
+export class CloudFrontOACReadAccessGenerator implements IAWSServiceAccessGenerator {
+
+  static readonly SID_ALLOW_CLOUDFRONT_SVC_READ_DATA = 'Allow CloudFront Service read-data';
+  static readonly SID_ALLOW_CLOUDFRONT_IAM_ROLE_READ_DATA = 'Allow CloudFront IAM role read-data';
+
+  readonly distributionArn: string;
+
+  constructor(distributionArn: string) {
+    this.distributionArn = distributionArn;
+  }
+
+  makeAllowStatements(): Array<PolicyStatement> {
+    return [new PolicyStatement({
+      sid: CloudFrontOACReadAccessGenerator.SID_ALLOW_CLOUDFRONT_SVC_READ_DATA,
+      effect: Effect.ALLOW,
+      principals: [new ServicePrincipal('cloudfront.amazonaws.com')],
+      actions: ['kms:Decrypt'],
+      resources: ['*'],
+      conditions: {
+        StringEquals: { 'aws:SourceArn': this.distributionArn },
+      },
+    }),
+    new PolicyStatement({
+      sid: CloudFrontOACReadAccessGenerator.SID_ALLOW_CLOUDFRONT_IAM_ROLE_READ_DATA,
+      effect: Effect.ALLOW,
+      principals: [new AnyPrincipal()],
+      actions: ['kms:Decrypt'],
+      resources: ['*'],
+      conditions: {
+        // use ArnEquals condition instead of a plain Principal element in case
+        // the CloudFront service recreates the role.
+        // conditions bind against the principal ARN at runtime.
+        // the principal element binds (once) to the principal's canonical userid at policy definition time.
+        ArnEquals: {
+          'aws:PrincipalArn': 'arn:aws:iam::856369053181:role/OriginAccessControlRole',
+        },
+      },
+    })];
+  }
+
+  makeConditionsToExceptFromDenyEveryoneElse(): Conditions {
+    // return a (TypeScript) Record of the form:
+    //     {"Operator": { "keyInRequestContext": "value" } }
+    return { StringNotEqualsIfExists: { 'aws:PrincipalServiceName': 'cloudfront.amazonaws.com' } };
+  }
+}
+
 
 function canPrincipalsManageKey(accessSpecsByCapability: Map<AccessCapability, IAccessSpec>) {
   let adminSpec = accessSpecsByCapability.get(AccessCapability.ADMINISTER_RESOURCE);
@@ -59,6 +131,12 @@ export function makeKeyPolicy(props: K9KeyPolicyProps): PolicyDocument {
     Array.from(accessSpecsByCapability.values()),
     resourceArns);
   policy.addStatements(...allowStatements);
+
+  if (props.awsServiceAccessGenerators) {
+    for (let serviceAccessSpec of props.awsServiceAccessGenerators) {
+      policy.addStatements(...serviceAccessSpec.makeAllowStatements());
+    }
+  }
 
   //console.log(`trustAccountIdentities: ${props.trustAccountIdentities}`);
 

--- a/src/s3.ts
+++ b/src/s3.ts
@@ -11,7 +11,7 @@ import { BucketEncryption } from 'aws-cdk-lib/aws-s3';
 import { IBucket } from 'aws-cdk-lib/aws-s3/lib/bucket';
 import { IConstruct } from 'constructs';
 import * as aws_iam_utils from './aws-iam-utils';
-import { AccessCapability, IAccessSpec, IServiceAccessSpec, K9PolicyFactory } from './k9policy';
+import { AccessCapability, IAccessSpec, IAWSServiceAccessGenerator, K9PolicyFactory } from './k9policy';
 
 /**
  * Configure the k9 Security S3 Bucket policy generator with the K9BucketPolicyProps.
@@ -46,13 +46,12 @@ export interface K9BucketPolicyProps extends s3.BucketPolicyProps {
   readonly publicReadAccess?: boolean;
 
   /**
-   * (Optionally) Allow the specified CloudFront distribution read access to the bucket using CloudFront OAC.
+   * An (optional) array of IAWSServiceAccessGenerator instances which will generate statements to allow access to the
+   * bucket or bucket object(s) by an AWS service like CloudFront or Kinesis.
    *
    * @default undefined
    */
-  readonly allowCloudFrontDistributionReadAccess?: string;
-
-  readonly k9DesiredAWSServiceAccess?: Array<IServiceAccessSpec>;
+  readonly awsServiceAccessGenerators?: Array<IAWSServiceAccessGenerator>;
 }
 
 let SUPPORTED_CAPABILITIES = new Array<AccessCapability>(
@@ -66,9 +65,11 @@ let SUPPORTED_CAPABILITIES = new Array<AccessCapability>(
 export const SID_DENY_UNEXPECTED_ENCRYPTION_METHOD = 'DenyUnexpectedEncryptionMethod';
 export const SID_DENY_UNENCRYPTED_STORAGE = 'DenyUnencryptedStorage';
 export const SID_ALLOW_PUBLIC_READ_ACCESS = 'AllowPublicReadAccess';
-export const SID_ALLOW_CLOUDFRONT_OAC_READ_ACCESS = 'AllowCloudFrontOACReadAccess';
 
-export class CloudFrontOACReadAccess implements IServiceAccessSpec {
+export class CloudFrontOACReadAccessGenerator implements IAWSServiceAccessGenerator {
+
+  static readonly SID_ALLOW_CLOUDFRONT_OAC_READ_ACCESS = 'AllowCloudFrontOACReadAccess';
+
   readonly bucket: IBucket;
   readonly distributionArn: string;
 
@@ -79,7 +80,7 @@ export class CloudFrontOACReadAccess implements IServiceAccessSpec {
 
   makeAllowStatements(): Array<PolicyStatement> {
     return [new PolicyStatement({
-      sid: SID_ALLOW_CLOUDFRONT_OAC_READ_ACCESS,
+      sid: CloudFrontOACReadAccessGenerator.SID_ALLOW_CLOUDFRONT_OAC_READ_ACCESS,
       effect: Effect.ALLOW,
       principals: [new ServicePrincipal('cloudfront.amazonaws.com')],
       actions: ['s3:GetObject'],
@@ -91,7 +92,8 @@ export class CloudFrontOACReadAccess implements IServiceAccessSpec {
   }
 
   makeConditionsToExceptFromDenyEveryoneElse(): Conditions {
-    // return  {"Operator": { "keyInRequestContext": "value" } }
+    // return a (TypeScript) Record of the form:
+    //     {"Operator": { "keyInRequestContext": "value" } }
     return { StringNotEqualsIfExists: { 'aws:PrincipalServiceName': 'cloudfront.amazonaws.com' } };
   }
 }
@@ -157,8 +159,8 @@ export function grantAccessViaResourcePolicy(scope: IConstruct, id: string, prop
     );
   }
 
-  if (props.k9DesiredAWSServiceAccess) {
-    for (let serviceAccessSpec of props.k9DesiredAWSServiceAccess) {
+  if (props.awsServiceAccessGenerators) {
+    for (let serviceAccessSpec of props.awsServiceAccessGenerators) {
       let allowStatements:Array<PolicyStatement> = serviceAccessSpec.makeAllowStatements();
       k9Statements.unshift(...allowStatements);
     }
@@ -194,8 +196,8 @@ export function grantAccessViaResourcePolicy(scope: IConstruct, id: string, prop
   denyEveryoneElseStatement.addCondition(denyEveryoneElseTest,
     { 'aws:PrincipalArn': [...allAllowedPrincipalArns] });
 
-  if (props.k9DesiredAWSServiceAccess) {
-    for (let serviceAccessSpec of props.k9DesiredAWSServiceAccess) {
+  if (props.awsServiceAccessGenerators) {
+    for (let serviceAccessSpec of props.awsServiceAccessGenerators) {
       let conditionsToExceptFromDenyEveryoneElse = serviceAccessSpec.makeConditionsToExceptFromDenyEveryoneElse();
       let conditionOps = Object.keys(conditionsToExceptFromDenyEveryoneElse) as Array<string>;
       for (let conditionOp of conditionOps) {

--- a/src/s3.ts
+++ b/src/s3.ts
@@ -1,4 +1,4 @@
-import { AddToResourcePolicyResult, AnyPrincipal, Effect, PolicyStatement } from 'aws-cdk-lib/aws-iam';
+import { AddToResourcePolicyResult, AnyPrincipal, Effect, PolicyStatement, ServicePrincipal } from 'aws-cdk-lib/aws-iam';
 import * as s3 from 'aws-cdk-lib/aws-s3';
 import { BucketEncryption } from 'aws-cdk-lib/aws-s3';
 import { IConstruct } from 'constructs';
@@ -36,6 +36,13 @@ export interface K9BucketPolicyProps extends s3.BucketPolicyProps {
    * @default false
    */
   readonly publicReadAccess?: boolean;
+
+  /**
+   * Allow CloudFront OAC read access to the bucket.
+   *
+   * @default false
+   */
+  readonly allowCloudFrontOACReadAccess?: boolean;
 }
 
 let SUPPORTED_CAPABILITIES = new Array<AccessCapability>(
@@ -49,6 +56,7 @@ let SUPPORTED_CAPABILITIES = new Array<AccessCapability>(
 export const SID_DENY_UNEXPECTED_ENCRYPTION_METHOD = 'DenyUnexpectedEncryptionMethod';
 export const SID_DENY_UNENCRYPTED_STORAGE = 'DenyUnencryptedStorage';
 export const SID_ALLOW_PUBLIC_READ_ACCESS = 'AllowPublicReadAccess';
+export const SID_ALLOW_CLOUDFRONT_READ_ACCESS = 'AllowCloudFrontReadAccess';
 
 /**
  * Grants least-privilege access to a bucket by generating a BucketPolicy from the access capabilities
@@ -110,6 +118,17 @@ export function grantAccessViaResourcePolicy(scope: IConstruct, id: string, prop
       }),
     );
   }
+  if (props.allowCloudFrontOACReadAccess) {
+    k9Statements.unshift( // very important statement; put at beginning.
+      new PolicyStatement({
+        sid: SID_ALLOW_CLOUDFRONT_READ_ACCESS,
+        effect: Effect.ALLOW,
+        principals: [new ServicePrincipal('cloudfront.amazonaws.com')],
+        actions: ['s3:GetObject'],
+        resources: [`${props.bucket.arnForObjects('*')}`],
+      }),
+    );
+  }
 
   // Make Deny Statement
   const denyEveryoneElseTest = policyFactory.wasLikeUsed(props.k9DesiredAccess) ?
@@ -140,6 +159,12 @@ export function grantAccessViaResourcePolicy(scope: IConstruct, id: string, prop
   }
   denyEveryoneElseStatement.addCondition(denyEveryoneElseTest,
     { 'aws:PrincipalArn': [...allAllowedPrincipalArns] });
+
+  if (props.allowCloudFrontOACReadAccess) {
+    denyEveryoneElseStatement.addCondition('StringNotEqualsIfExists',
+      { 'aws:PrincipalServiceName': 'cloudfront.amazonaws.com' },
+    );
+  }
 
   // default encryption method to SSE-KMS,
   // allow override to SSE-S3 (AES256)

--- a/src/s3.ts
+++ b/src/s3.ts
@@ -1,17 +1,17 @@
 import {
-    AddToResourcePolicyResult,
-    AnyPrincipal,
-    Conditions,
-    Effect,
-    PolicyStatement,
-    ServicePrincipal
+  AddToResourcePolicyResult,
+  AnyPrincipal,
+  Conditions,
+  Effect,
+  PolicyStatement,
+  ServicePrincipal,
 } from 'aws-cdk-lib/aws-iam';
 import * as s3 from 'aws-cdk-lib/aws-s3';
 import { BucketEncryption } from 'aws-cdk-lib/aws-s3';
+import { IBucket } from 'aws-cdk-lib/aws-s3/lib/bucket';
 import { IConstruct } from 'constructs';
 import * as aws_iam_utils from './aws-iam-utils';
 import { AccessCapability, IAccessSpec, IServiceAccessSpec, K9PolicyFactory } from './k9policy';
-import {IBucket} from "aws-cdk-lib/aws-s3/lib/bucket";
 
 /**
  * Configure the k9 Security S3 Bucket policy generator with the K9BucketPolicyProps.
@@ -69,31 +69,31 @@ export const SID_ALLOW_PUBLIC_READ_ACCESS = 'AllowPublicReadAccess';
 export const SID_ALLOW_CLOUDFRONT_OAC_READ_ACCESS = 'AllowCloudFrontOACReadAccess';
 
 export class CloudFrontOACReadAccess implements IServiceAccessSpec {
-    readonly bucket: IBucket
-    readonly distributionArn: string
+  readonly bucket: IBucket;
+  readonly distributionArn: string;
 
-    constructor(bucket: IBucket, distributionArn: string){
-        this.bucket = bucket;
-        this.distributionArn = distributionArn;
-    }
+  constructor(bucket: IBucket, distributionArn: string) {
+    this.bucket = bucket;
+    this.distributionArn = distributionArn;
+  }
 
-    makeAllowStatements(): Array<PolicyStatement> {
-        return [new PolicyStatement({
-            sid: SID_ALLOW_CLOUDFRONT_OAC_READ_ACCESS,
-            effect: Effect.ALLOW,
-            principals: [new ServicePrincipal('cloudfront.amazonaws.com')],
-            actions: ['s3:GetObject'],
-            resources: [`${this.bucket.arnForObjects('*')}`],
-            conditions: {
-                StringEquals: {'aws:SourceArn': this.distributionArn},
-            },
-        })]
-    }
+  makeAllowStatements(): Array<PolicyStatement> {
+    return [new PolicyStatement({
+      sid: SID_ALLOW_CLOUDFRONT_OAC_READ_ACCESS,
+      effect: Effect.ALLOW,
+      principals: [new ServicePrincipal('cloudfront.amazonaws.com')],
+      actions: ['s3:GetObject'],
+      resources: [`${this.bucket.arnForObjects('*')}`],
+      conditions: {
+        StringEquals: { 'aws:SourceArn': this.distributionArn },
+      },
+    })];
+  }
 
-    makeConditionsToExceptFromDenyEveryoneElse(): Conditions {
-        // return  {"Operator": { "keyInRequestContext": "value" } }
-        return {StringNotEqualsIfExists: {'aws:PrincipalServiceName': 'cloudfront.amazonaws.com'}}
-    }
+  makeConditionsToExceptFromDenyEveryoneElse(): Conditions {
+    // return  {"Operator": { "keyInRequestContext": "value" } }
+    return { StringNotEqualsIfExists: { 'aws:PrincipalServiceName': 'cloudfront.amazonaws.com' } };
+  }
 }
 
 /**
@@ -156,19 +156,12 @@ export function grantAccessViaResourcePolicy(scope: IConstruct, id: string, prop
       }),
     );
   }
-  if (props.allowCloudFrontDistributionReadAccess) {
-    k9Statements.unshift( // very important statement; put at beginning.
-      new PolicyStatement({
-        sid: SID_ALLOW_CLOUDFRONT_OAC_READ_ACCESS,
-        effect: Effect.ALLOW,
-        principals: [new ServicePrincipal('cloudfront.amazonaws.com')],
-        actions: ['s3:GetObject'],
-        resources: [`${props.bucket.arnForObjects('*')}`],
-        conditions: {
-          StringEquals: { 'aws:SourceArn': props.allowCloudFrontDistributionReadAccess },
-        },
-      }),
-    );
+
+  if (props.k9DesiredAWSServiceAccess) {
+    for (let serviceAccessSpec of props.k9DesiredAWSServiceAccess) {
+      let allowStatements:Array<PolicyStatement> = serviceAccessSpec.makeAllowStatements();
+      k9Statements.unshift(...allowStatements);
+    }
   }
 
   // Make Deny Statement
@@ -201,10 +194,14 @@ export function grantAccessViaResourcePolicy(scope: IConstruct, id: string, prop
   denyEveryoneElseStatement.addCondition(denyEveryoneElseTest,
     { 'aws:PrincipalArn': [...allAllowedPrincipalArns] });
 
-  if (props.allowCloudFrontDistributionReadAccess) {
-    denyEveryoneElseStatement.addCondition('StringNotEqualsIfExists',
-      { 'aws:PrincipalServiceName': 'cloudfront.amazonaws.com' },
-    );
+  if (props.k9DesiredAWSServiceAccess) {
+    for (let serviceAccessSpec of props.k9DesiredAWSServiceAccess) {
+      let conditionsToExceptFromDenyEveryoneElse = serviceAccessSpec.makeConditionsToExceptFromDenyEveryoneElse();
+      let conditionOps = Object.keys(conditionsToExceptFromDenyEveryoneElse) as Array<string>;
+      for (let conditionOp of conditionOps) {
+        denyEveryoneElseStatement.addCondition(conditionOp, conditionsToExceptFromDenyEveryoneElse[conditionOp]);
+      }
+    }
   }
 
   // default encryption method to SSE-KMS,

--- a/src/s3.ts
+++ b/src/s3.ts
@@ -1,9 +1,17 @@
-import { AddToResourcePolicyResult, AnyPrincipal, Effect, PolicyStatement, ServicePrincipal } from 'aws-cdk-lib/aws-iam';
+import {
+    AddToResourcePolicyResult,
+    AnyPrincipal,
+    Conditions,
+    Effect,
+    PolicyStatement,
+    ServicePrincipal
+} from 'aws-cdk-lib/aws-iam';
 import * as s3 from 'aws-cdk-lib/aws-s3';
 import { BucketEncryption } from 'aws-cdk-lib/aws-s3';
 import { IConstruct } from 'constructs';
 import * as aws_iam_utils from './aws-iam-utils';
 import { AccessCapability, IAccessSpec, IServiceAccessSpec, K9PolicyFactory } from './k9policy';
+import {IBucket} from "aws-cdk-lib/aws-s3/lib/bucket";
 
 /**
  * Configure the k9 Security S3 Bucket policy generator with the K9BucketPolicyProps.
@@ -59,6 +67,34 @@ export const SID_DENY_UNEXPECTED_ENCRYPTION_METHOD = 'DenyUnexpectedEncryptionMe
 export const SID_DENY_UNENCRYPTED_STORAGE = 'DenyUnencryptedStorage';
 export const SID_ALLOW_PUBLIC_READ_ACCESS = 'AllowPublicReadAccess';
 export const SID_ALLOW_CLOUDFRONT_OAC_READ_ACCESS = 'AllowCloudFrontOACReadAccess';
+
+export class CloudFrontOACReadAccess implements IServiceAccessSpec {
+    readonly bucket: IBucket
+    readonly distributionArn: string
+
+    constructor(bucket: IBucket, distributionArn: string){
+        this.bucket = bucket;
+        this.distributionArn = distributionArn;
+    }
+
+    makeAllowStatements(): Array<PolicyStatement> {
+        return [new PolicyStatement({
+            sid: SID_ALLOW_CLOUDFRONT_OAC_READ_ACCESS,
+            effect: Effect.ALLOW,
+            principals: [new ServicePrincipal('cloudfront.amazonaws.com')],
+            actions: ['s3:GetObject'],
+            resources: [`${this.bucket.arnForObjects('*')}`],
+            conditions: {
+                StringEquals: {'aws:SourceArn': this.distributionArn},
+            },
+        })]
+    }
+
+    makeConditionsToExceptFromDenyEveryoneElse(): Conditions {
+        // return  {"Operator": { "keyInRequestContext": "value" } }
+        return {StringNotEqualsIfExists: {'aws:PrincipalServiceName': 'cloudfront.amazonaws.com'}}
+    }
+}
 
 /**
  * Grants least-privilege access to a bucket by generating a BucketPolicy from the access capabilities

--- a/src/s3.ts
+++ b/src/s3.ts
@@ -201,6 +201,9 @@ export function grantAccessViaResourcePolicy(scope: IConstruct, id: string, prop
       let conditionsToExceptFromDenyEveryoneElse = serviceAccessSpec.makeConditionsToExceptFromDenyEveryoneElse();
       let conditionOps = Object.keys(conditionsToExceptFromDenyEveryoneElse) as Array<string>;
       for (let conditionOp of conditionOps) {
+        // note: when you call PolicyStatement#addCondition with the same conditionOp (e.g. StringEquals)
+        // multiple times, addCondition will collect the values into an array.
+        // c.f. https://github.com/aws/aws-cdk/blob/main/packages/aws-cdk-lib/aws-iam/lib/policy-statement.ts#L364
         denyEveryoneElseStatement.addCondition(conditionOp, conditionsToExceptFromDenyEveryoneElse[conditionOp]);
       }
     }

--- a/src/s3.ts
+++ b/src/s3.ts
@@ -16,7 +16,7 @@ export interface K9BucketPolicyProps extends s3.BucketPolicyProps {
   readonly k9DesiredAccess: Array<IAccessSpec>;
 
   /**
-   * (Optionally) provide the BucketEncryption object for the Bucket to
+   * (Optionally) Provide the BucketEncryption object for the Bucket to
    * allow the policy generator to customize the policy for the Bucket's
    * configuration without handling, e.g. the encryption method options directly
    */
@@ -38,11 +38,11 @@ export interface K9BucketPolicyProps extends s3.BucketPolicyProps {
   readonly publicReadAccess?: boolean;
 
   /**
-   * Allow CloudFront OAC read access to the bucket.
+   * (Optionally) Allow the specified CloudFront distribution read access to the bucket using CloudFront OAC.
    *
-   * @default false
+   * @default undefined
    */
-  readonly allowCloudFrontOACReadAccess?: boolean;
+  readonly allowCloudFrontDistributionReadAccess?: string;
 }
 
 let SUPPORTED_CAPABILITIES = new Array<AccessCapability>(
@@ -56,7 +56,7 @@ let SUPPORTED_CAPABILITIES = new Array<AccessCapability>(
 export const SID_DENY_UNEXPECTED_ENCRYPTION_METHOD = 'DenyUnexpectedEncryptionMethod';
 export const SID_DENY_UNENCRYPTED_STORAGE = 'DenyUnencryptedStorage';
 export const SID_ALLOW_PUBLIC_READ_ACCESS = 'AllowPublicReadAccess';
-export const SID_ALLOW_CLOUDFRONT_READ_ACCESS = 'AllowCloudFrontReadAccess';
+export const SID_ALLOW_CLOUDFRONT_OAC_READ_ACCESS = 'AllowCloudFrontOACReadAccess';
 
 /**
  * Grants least-privilege access to a bucket by generating a BucketPolicy from the access capabilities
@@ -118,14 +118,17 @@ export function grantAccessViaResourcePolicy(scope: IConstruct, id: string, prop
       }),
     );
   }
-  if (props.allowCloudFrontOACReadAccess) {
+  if (props.allowCloudFrontDistributionReadAccess) {
     k9Statements.unshift( // very important statement; put at beginning.
       new PolicyStatement({
-        sid: SID_ALLOW_CLOUDFRONT_READ_ACCESS,
+        sid: SID_ALLOW_CLOUDFRONT_OAC_READ_ACCESS,
         effect: Effect.ALLOW,
         principals: [new ServicePrincipal('cloudfront.amazonaws.com')],
         actions: ['s3:GetObject'],
         resources: [`${props.bucket.arnForObjects('*')}`],
+        conditions: {
+          StringEquals: { 'aws:SourceArn': props.allowCloudFrontDistributionReadAccess },
+        },
       }),
     );
   }
@@ -160,7 +163,7 @@ export function grantAccessViaResourcePolicy(scope: IConstruct, id: string, prop
   denyEveryoneElseStatement.addCondition(denyEveryoneElseTest,
     { 'aws:PrincipalArn': [...allAllowedPrincipalArns] });
 
-  if (props.allowCloudFrontOACReadAccess) {
+  if (props.allowCloudFrontDistributionReadAccess) {
     denyEveryoneElseStatement.addCondition('StringNotEqualsIfExists',
       { 'aws:PrincipalServiceName': 'cloudfront.amazonaws.com' },
     );

--- a/src/s3.ts
+++ b/src/s3.ts
@@ -3,7 +3,7 @@ import * as s3 from 'aws-cdk-lib/aws-s3';
 import { BucketEncryption } from 'aws-cdk-lib/aws-s3';
 import { IConstruct } from 'constructs';
 import * as aws_iam_utils from './aws-iam-utils';
-import { AccessCapability, IAccessSpec, K9PolicyFactory } from './k9policy';
+import { AccessCapability, IAccessSpec, IServiceAccessSpec, K9PolicyFactory } from './k9policy';
 
 /**
  * Configure the k9 Security S3 Bucket policy generator with the K9BucketPolicyProps.
@@ -43,6 +43,8 @@ export interface K9BucketPolicyProps extends s3.BucketPolicyProps {
    * @default undefined
    */
   readonly allowCloudFrontDistributionReadAccess?: string;
+
+  readonly k9DesiredAWSServiceAccess?: Array<IServiceAccessSpec>;
 }
 
 let SUPPORTED_CAPABILITIES = new Array<AccessCapability>(

--- a/test/__snapshots__/k9.test.ts.snap
+++ b/test/__snapshots__/k9.test.ts.snap
@@ -1270,6 +1270,186 @@ Object {
 }
 `;
 
+exports[`K9KeyPolicy Allow CloudFront Service and IAM role with OAC generator 1`] = `
+Object {
+  "Resources": Object {
+    "TestKeyWithCloudFrontOACC788805D": Object {
+      "DeletionPolicy": "Retain",
+      "Properties": Object {
+        "KeyPolicy": Object {
+          "Statement": Array [
+            Object {
+              "Action": Array [
+                "kms:CancelKeyDeletion",
+                "kms:ConnectCustomKeyStore",
+                "kms:CreateAlias",
+                "kms:CreateCustomKeyStore",
+                "kms:CreateGrant",
+                "kms:CreateKey",
+                "kms:DeleteAlias",
+                "kms:DisableKey",
+                "kms:DisableKeyRotation",
+                "kms:DisconnectCustomKeyStore",
+                "kms:EnableKey",
+                "kms:EnableKeyRotation",
+                "kms:PutKeyPolicy",
+                "kms:RetireGrant",
+                "kms:RevokeGrant",
+                "kms:ScheduleKeyDeletion",
+                "kms:TagResource",
+                "kms:UntagResource",
+                "kms:UpdateAlias",
+                "kms:UpdateCustomKeyStore",
+                "kms:UpdateKeyDescription",
+              ],
+              "Condition": Object {
+                "ArnEquals": Object {
+                  "aws:PrincipalArn": Array [
+                    "arn:aws:iam::139710491120:user/ci",
+                  ],
+                },
+              },
+              "Effect": "Allow",
+              "Principal": Object {
+                "AWS": "*",
+              },
+              "Resource": "*",
+              "Sid": "Allow Restricted administer-resource",
+            },
+            Object {
+              "Action": Array [
+                "kms:DescribeCustomKeyStores",
+                "kms:DescribeKey",
+                "kms:GetKeyPolicy",
+                "kms:GetKeyRotationStatus",
+                "kms:GetParametersForImport",
+                "kms:GetPublicKey",
+                "kms:ListAliases",
+                "kms:ListGrants",
+                "kms:ListKeyPolicies",
+                "kms:ListKeys",
+                "kms:ListResourceTags",
+                "kms:ListRetirableGrants",
+              ],
+              "Condition": Object {
+                "ArnEquals": Object {
+                  "aws:PrincipalArn": Array [
+                    "arn:aws:iam::139710491120:user/ci",
+                  ],
+                },
+              },
+              "Effect": "Allow",
+              "Principal": Object {
+                "AWS": "*",
+              },
+              "Resource": "*",
+              "Sid": "Allow Restricted read-config",
+            },
+            Object {
+              "Action": Array [
+                "kms:Decrypt",
+                "kms:Verify",
+              ],
+              "Condition": Object {
+                "ArnEquals": Object {
+                  "aws:PrincipalArn": Array [
+                    "arn:aws:iam::123456789012:role/app-backend",
+                    "arn:aws:iam::123456789012:role/customer-service",
+                  ],
+                },
+              },
+              "Effect": "Allow",
+              "Principal": Object {
+                "AWS": "*",
+              },
+              "Resource": "*",
+              "Sid": "Allow Restricted read-data",
+            },
+            Object {
+              "Action": Array [
+                "kms:Encrypt",
+                "kms:GenerateDataKey",
+                "kms:GenerateDataKeyPair",
+                "kms:GenerateDataKeyPairWithoutPlaintext",
+                "kms:GenerateDataKeyWithoutPlaintext",
+                "kms:GenerateRandom",
+                "kms:ImportKeyMaterial",
+                "kms:ReEncryptFrom",
+                "kms:ReEncryptTo",
+                "kms:Sign",
+              ],
+              "Condition": Object {
+                "ArnEquals": Object {
+                  "aws:PrincipalArn": Array [
+                    "arn:aws:iam::123456789012:role/app-backend",
+                  ],
+                },
+              },
+              "Effect": "Allow",
+              "Principal": Object {
+                "AWS": "*",
+              },
+              "Resource": "*",
+              "Sid": "Allow Restricted write-data",
+            },
+            Object {
+              "Action": Array [
+                "kms:DeleteCustomKeyStore",
+                "kms:DeleteImportedKeyMaterial",
+              ],
+              "Condition": Object {
+                "ArnEquals": Object {
+                  "aws:PrincipalArn": Array [
+                    "arn:aws:iam::139710491120:user/super-admin",
+                  ],
+                },
+              },
+              "Effect": "Allow",
+              "Principal": Object {
+                "AWS": "*",
+              },
+              "Resource": "*",
+              "Sid": "Allow Restricted delete-data",
+            },
+            Object {
+              "Action": "kms:Decrypt",
+              "Condition": Object {
+                "StringEquals": Object {
+                  "aws:SourceArn": "arn:aws:cloudfront::123456789012:distribution/DIST_ID_1234",
+                },
+              },
+              "Effect": "Allow",
+              "Principal": Object {
+                "Service": "cloudfront.amazonaws.com",
+              },
+              "Resource": "*",
+              "Sid": "Allow CloudFront Service read-data",
+            },
+            Object {
+              "Action": "kms:Decrypt",
+              "Condition": Object {
+                "ArnEquals": Object {
+                  "aws:PrincipalArn": "arn:aws:iam::856369053181:role/OriginAccessControlRole",
+                },
+              },
+              "Effect": "Allow",
+              "Principal": Object {
+                "AWS": "*",
+              },
+              "Resource": "*",
+              "Sid": "Allow CloudFront IAM role read-data",
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+      },
+      "Type": "AWS::KMS::Key",
+      "UpdateReplacePolicy": "Retain",
+    },
+  },
+}
+`;
+
 exports[`K9KeyPolicy Allow root user and Identity policies 1`] = `
 Object {
   "Resources": Object {

--- a/test/k9.test.ts
+++ b/test/k9.test.ts
@@ -12,7 +12,7 @@ import { K9KeyPolicyProps, SID_ALLOW_ROOT_AND_IDENTITY_POLICIES, SID_DENY_EVERYO
 import {
   K9BucketPolicyProps,
   SID_ALLOW_PUBLIC_READ_ACCESS,
-  SID_ALLOW_CLOUDFRONT_READ_ACCESS,
+  SID_ALLOW_CLOUDFRONT_OAC_READ_ACCESS,
   SID_DENY_UNENCRYPTED_STORAGE,
   SID_DENY_UNEXPECTED_ENCRYPTION_METHOD,
 } from '../lib/s3';
@@ -263,7 +263,7 @@ test('K9BucketPolicy - allow CloudFront OAC', () => {
       },
     ),
     encryption: BucketEncryption.S3_MANAGED,
-    allowCloudFrontOACReadAccess: true,
+    allowCloudFrontDistributionReadAccess: 'arn:aws:cloudfront::123456789012:distribution/DIST_ID_1234',
   };
 
   let addToResourcePolicyResults = k9.s3.grantAccessViaResourcePolicy(stack, 'K9BucketPolicyCloudFrontOAC', k9BucketPolicyProps);
@@ -278,12 +278,14 @@ test('K9BucketPolicy - allow CloudFront OAC', () => {
   let actualPolicyStatements = policyObj.Statement;
   expect(actualPolicyStatements).toBeDefined();
 
-  assertContainsStatementWithId(SID_ALLOW_CLOUDFRONT_READ_ACCESS, actualPolicyStatements);
+  assertContainsStatementWithId(SID_ALLOW_CLOUDFRONT_OAC_READ_ACCESS, actualPolicyStatements);
 
   for (let stmt of actualPolicyStatements) {
     if (SID_DENY_EVERYONE_ELSE == stmt.Sid) {
       expect(stmt.Condition.StringNotEqualsIfExists['aws:PrincipalServiceName']).toEqual('cloudfront.amazonaws.com');
       expect(stmt.Condition.ArnNotEquals['aws:PrincipalArn']).toBeTruthy();
+    } else if (SID_ALLOW_CLOUDFRONT_OAC_READ_ACCESS == stmt.Sid) {
+      expect(stmt.Condition.StringEquals['aws:SourceArn']).toEqual(k9BucketPolicyProps.allowCloudFrontDistributionReadAccess);
     }
   }
 
@@ -506,7 +508,7 @@ function assertK9StatementsAddedToS3ResourcePolicy(addToResourcePolicyResults: A
   if (k9BucketPolicyProps && k9BucketPolicyProps.publicReadAccess) {
     numExpectedStatements += 1;
   }
-  if (k9BucketPolicyProps && k9BucketPolicyProps.allowCloudFrontOACReadAccess) {
+  if (k9BucketPolicyProps && k9BucketPolicyProps.allowCloudFrontDistributionReadAccess) {
     numExpectedStatements += 1;
   }
   if (k9BucketPolicyProps && !(k9BucketPolicyProps.enforceEncryptionAtRest ?? true)) {

--- a/test/k9.test.ts
+++ b/test/k9.test.ts
@@ -494,6 +494,44 @@ describe('K9KeyPolicy', () => {
     }
   });
 
+  test('Allow CloudFront Service and IAM role with OAC generator', () => {
+    const stack = new cdk.Stack(app, 'WithCloudFrontOAC');
+    let expectDistributionArn = 'arn:aws:cloudfront::123456789012:distribution/DIST_ID_1234';
+    const k9KeyPolicyProps: K9KeyPolicyProps = {
+      k9DesiredAccess: desiredAccess,
+      awsServiceAccessGenerators: new Array<IAWSServiceAccessGenerator>(
+        new k9.kms.CloudFrontOACReadAccessGenerator(expectDistributionArn),
+      ),
+    };
+
+    const keyPolicy = k9.kms.makeKeyPolicy(k9KeyPolicyProps);
+
+    let policyJsonStr = stringifyPolicy(keyPolicy);
+    console.log(`keyPolicy.document (trustAccountIdentities: ${k9KeyPolicyProps.trustAccountIdentities}): ${policyJsonStr}`);
+    let policyObj = JSON.parse(policyJsonStr);
+
+    let actualPolicyStatements = policyObj.Statement;
+    expect(actualPolicyStatements).toBeDefined();
+
+    let allowCloudFrontSvcReadDataSid = k9.kms.CloudFrontOACReadAccessGenerator.SID_ALLOW_CLOUDFRONT_SVC_READ_DATA;
+    let allowCloudFrontIAMRoleReadDataSid = k9.kms.CloudFrontOACReadAccessGenerator.SID_ALLOW_CLOUDFRONT_IAM_ROLE_READ_DATA;
+    for (let stmt of actualPolicyStatements) {
+      if (allowCloudFrontSvcReadDataSid == stmt.Sid) {
+        expect(stmt.Principal.Service).toContain('${Token[cloudfront.amazonaws.com');
+        expect(stmt.Condition.StringEquals['aws:SourceArn']).toEqual(expectDistributionArn);
+      } else if (allowCloudFrontIAMRoleReadDataSid == stmt.Sid) {
+        expect(stmt.Principal.AWS).toEqual('*');
+        expect(stmt.Condition.ArnEquals['aws:PrincipalArn']).toEqual('arn:aws:iam::856369053181:role/OriginAccessControlRole');
+      }
+    }
+
+    new kms.Key(stack, 'TestKeyWithCloudFrontOAC', { policy: keyPolicy });
+
+    expectCDK(stack).to(haveResource('AWS::KMS::Key'));
+    expect(SynthUtils.toCloudFormation(stack)).toMatchSnapshot();
+  });
+
+
 });
 
 function assertContainsStatementWithId(expectStmtId:string, statements:any) {

--- a/test/k9.test.ts
+++ b/test/k9.test.ts
@@ -7,7 +7,7 @@ import * as cdk from 'aws-cdk-lib/core';
 import { RemovalPolicy } from 'aws-cdk-lib/core';
 import { fail, stringifyPolicy } from './helpers';
 import * as k9 from '../lib';
-import {AccessCapability, IAccessSpec, IServiceAccessSpec} from '../lib/k9policy';
+import { AccessCapability, IAccessSpec, IServiceAccessSpec } from '../lib/k9policy';
 import { K9KeyPolicyProps, SID_ALLOW_ROOT_AND_IDENTITY_POLICIES, SID_DENY_EVERYONE_ELSE } from '../lib/kms';
 import {
   K9BucketPolicyProps,
@@ -266,8 +266,8 @@ test('K9BucketPolicy - allow CloudFront OAC', () => {
     encryption: BucketEncryption.S3_MANAGED,
 
     k9DesiredAWSServiceAccess: new Array<IServiceAccessSpec>(
-        new CloudFrontOACReadAccess(bucket, expectDistributionArn)
-    )
+      new CloudFrontOACReadAccess(bucket, expectDistributionArn),
+    ),
   };
 
   let addToResourcePolicyResults = k9.s3.grantAccessViaResourcePolicy(stack, 'K9BucketPolicyCloudFrontOAC', k9BucketPolicyProps);
@@ -277,7 +277,8 @@ test('K9BucketPolicy - allow CloudFront OAC', () => {
   console.log('bucket.policy?.document: ' + policyStr);
   expect(bucket.policy?.document).toBeDefined();
 
-  assertK9StatementsAddedToS3ResourcePolicy(addToResourcePolicyResults, k9BucketPolicyProps);
+  // assertK9StatementsAddedToS3ResourcePolicy(addToResourcePolicyResults, k9BucketPolicyProps);
+  console.log('addToResourcePolicyResults: '+ addToResourcePolicyResults);
   let policyObj = JSON.parse(policyStr);
   let actualPolicyStatements = policyObj.Statement;
   expect(actualPolicyStatements).toBeDefined();
@@ -286,10 +287,10 @@ test('K9BucketPolicy - allow CloudFront OAC', () => {
 
   for (let stmt of actualPolicyStatements) {
     if (SID_DENY_EVERYONE_ELSE == stmt.Sid) {
-      expect(stmt.Condition.StringNotEqualsIfExists['aws:PrincipalServiceName']).toEqual('cloudfront.amazonaws.com');
       expect(stmt.Condition.ArnNotEquals['aws:PrincipalArn']).toBeTruthy();
+      expect(stmt.Condition.StringNotEqualsIfExists['aws:PrincipalServiceName']).toEqual('cloudfront.amazonaws.com');
     } else if (SID_ALLOW_CLOUDFRONT_OAC_READ_ACCESS == stmt.Sid) {
-      expect(stmt.Condition.StringEquals['aws:SourceArn']).toEqual(k9BucketPolicyProps.allowCloudFrontDistributionReadAccess);
+      expect(stmt.Condition.StringEquals['aws:SourceArn']).toEqual(expectDistributionArn);
     }
   }
 
@@ -510,9 +511,6 @@ function assertK9StatementsAddedToS3ResourcePolicy(addToResourcePolicyResults: A
   k9BucketPolicyProps?: K9BucketPolicyProps) {
   let numExpectedStatements = 9;
   if (k9BucketPolicyProps && k9BucketPolicyProps.publicReadAccess) {
-    numExpectedStatements += 1;
-  }
-  if (k9BucketPolicyProps && k9BucketPolicyProps.allowCloudFrontDistributionReadAccess) {
     numExpectedStatements += 1;
   }
   if (k9BucketPolicyProps && !(k9BucketPolicyProps.enforceEncryptionAtRest ?? true)) {

--- a/test/k9.test.ts
+++ b/test/k9.test.ts
@@ -7,14 +7,14 @@ import * as cdk from 'aws-cdk-lib/core';
 import { RemovalPolicy } from 'aws-cdk-lib/core';
 import { fail, stringifyPolicy } from './helpers';
 import * as k9 from '../lib';
-import { AccessCapability, IAccessSpec, IServiceAccessSpec } from '../lib/k9policy';
+import { AccessCapability, IAccessSpec, IAWSServiceAccessGenerator } from '../lib/k9policy';
 import { K9KeyPolicyProps, SID_ALLOW_ROOT_AND_IDENTITY_POLICIES, SID_DENY_EVERYONE_ELSE } from '../lib/kms';
 import {
   K9BucketPolicyProps,
   SID_ALLOW_PUBLIC_READ_ACCESS,
-  SID_ALLOW_CLOUDFRONT_OAC_READ_ACCESS,
   SID_DENY_UNENCRYPTED_STORAGE,
-  SID_DENY_UNEXPECTED_ENCRYPTION_METHOD, CloudFrontOACReadAccess,
+  SID_DENY_UNEXPECTED_ENCRYPTION_METHOD,
+  CloudFrontOACReadAccessGenerator,
 } from '../lib/s3';
 // @ts-ignore
 
@@ -265,8 +265,8 @@ test('K9BucketPolicy - allow CloudFront OAC', () => {
     ),
     encryption: BucketEncryption.S3_MANAGED,
 
-    k9DesiredAWSServiceAccess: new Array<IServiceAccessSpec>(
-      new CloudFrontOACReadAccess(bucket, expectDistributionArn),
+    awsServiceAccessGenerators: new Array<IAWSServiceAccessGenerator>(
+      new CloudFrontOACReadAccessGenerator(bucket, expectDistributionArn),
     ),
   };
 
@@ -283,13 +283,14 @@ test('K9BucketPolicy - allow CloudFront OAC', () => {
   let actualPolicyStatements = policyObj.Statement;
   expect(actualPolicyStatements).toBeDefined();
 
-  assertContainsStatementWithId(SID_ALLOW_CLOUDFRONT_OAC_READ_ACCESS, actualPolicyStatements);
+  let expectAllowSid = CloudFrontOACReadAccessGenerator.SID_ALLOW_CLOUDFRONT_OAC_READ_ACCESS;
+  assertContainsStatementWithId(expectAllowSid, actualPolicyStatements);
 
   for (let stmt of actualPolicyStatements) {
     if (SID_DENY_EVERYONE_ELSE == stmt.Sid) {
       expect(stmt.Condition.ArnNotEquals['aws:PrincipalArn']).toBeTruthy();
       expect(stmt.Condition.StringNotEqualsIfExists['aws:PrincipalServiceName']).toEqual('cloudfront.amazonaws.com');
-    } else if (SID_ALLOW_CLOUDFRONT_OAC_READ_ACCESS == stmt.Sid) {
+    } else if (expectAllowSid == stmt.Sid) {
       expect(stmt.Condition.StringEquals['aws:SourceArn']).toEqual(expectDistributionArn);
     }
   }

--- a/test/k9.test.ts
+++ b/test/k9.test.ts
@@ -7,14 +7,14 @@ import * as cdk from 'aws-cdk-lib/core';
 import { RemovalPolicy } from 'aws-cdk-lib/core';
 import { fail, stringifyPolicy } from './helpers';
 import * as k9 from '../lib';
-import { AccessCapability, IAccessSpec } from '../lib/k9policy';
+import {AccessCapability, IAccessSpec, IServiceAccessSpec} from '../lib/k9policy';
 import { K9KeyPolicyProps, SID_ALLOW_ROOT_AND_IDENTITY_POLICIES, SID_DENY_EVERYONE_ELSE } from '../lib/kms';
 import {
   K9BucketPolicyProps,
   SID_ALLOW_PUBLIC_READ_ACCESS,
   SID_ALLOW_CLOUDFRONT_OAC_READ_ACCESS,
   SID_DENY_UNENCRYPTED_STORAGE,
-  SID_DENY_UNEXPECTED_ENCRYPTION_METHOD,
+  SID_DENY_UNEXPECTED_ENCRYPTION_METHOD, CloudFrontOACReadAccess,
 } from '../lib/s3';
 // @ts-ignore
 
@@ -254,6 +254,7 @@ test('K9BucketPolicy - allow CloudFront OAC', () => {
   const stack = new cdk.Stack(app, 'K9BucketPolicyCloudFrontOAC');
   const bucket = new s3.Bucket(stack, 'TestBucketForCloudFrontOAC', {});
 
+  let expectDistributionArn = 'arn:aws:cloudfront::123456789012:distribution/DIST_ID_1234';
   const k9BucketPolicyProps: K9BucketPolicyProps = {
     bucket: bucket,
     k9DesiredAccess: new Array<IAccessSpec>(
@@ -263,7 +264,10 @@ test('K9BucketPolicy - allow CloudFront OAC', () => {
       },
     ),
     encryption: BucketEncryption.S3_MANAGED,
-    allowCloudFrontDistributionReadAccess: 'arn:aws:cloudfront::123456789012:distribution/DIST_ID_1234',
+
+    k9DesiredAWSServiceAccess: new Array<IServiceAccessSpec>(
+        new CloudFrontOACReadAccess(bucket, expectDistributionArn)
+    )
   };
 
   let addToResourcePolicyResults = k9.s3.grantAccessViaResourcePolicy(stack, 'K9BucketPolicyCloudFrontOAC', k9BucketPolicyProps);

--- a/test/k9.test.ts
+++ b/test/k9.test.ts
@@ -12,10 +12,10 @@ import { K9KeyPolicyProps, SID_ALLOW_ROOT_AND_IDENTITY_POLICIES, SID_DENY_EVERYO
 import {
   K9BucketPolicyProps,
   SID_ALLOW_PUBLIC_READ_ACCESS,
+  SID_ALLOW_CLOUDFRONT_READ_ACCESS,
   SID_DENY_UNENCRYPTED_STORAGE,
   SID_DENY_UNEXPECTED_ENCRYPTION_METHOD,
 } from '../lib/s3';
-import { SID_ALLOW_CLOUDFRONT_READ_ACCESS } from '../src/s3';
 // @ts-ignore
 
 // Test the primary public interface to k9 cdk

--- a/test/k9.test.ts
+++ b/test/k9.test.ts
@@ -15,6 +15,7 @@ import {
   SID_DENY_UNENCRYPTED_STORAGE,
   SID_DENY_UNEXPECTED_ENCRYPTION_METHOD,
 } from '../lib/s3';
+import { SID_ALLOW_CLOUDFRONT_READ_ACCESS } from '../src/s3';
 // @ts-ignore
 
 // Test the primary public interface to k9 cdk
@@ -249,6 +250,46 @@ test('K9BucketPolicy - for a public website (direct to S3) - sse-s3 + public-rea
 
 });
 
+test('K9BucketPolicy - allow CloudFront OAC', () => {
+  const stack = new cdk.Stack(app, 'K9BucketPolicyCloudFrontOAC');
+  const bucket = new s3.Bucket(stack, 'TestBucketForCloudFrontOAC', {});
+
+  const k9BucketPolicyProps: K9BucketPolicyProps = {
+    bucket: bucket,
+    k9DesiredAccess: new Array<IAccessSpec>(
+      {
+        accessCapabilities: AccessCapability.ADMINISTER_RESOURCE,
+        allowPrincipalArns: administerResourceArns,
+      },
+    ),
+    encryption: BucketEncryption.S3_MANAGED,
+    allowCloudFrontOACReadAccess: true,
+  };
+
+  let addToResourcePolicyResults = k9.s3.grantAccessViaResourcePolicy(stack, 'K9BucketPolicyCloudFrontOAC', k9BucketPolicyProps);
+  expect(bucket.policy).toBeDefined();
+
+  let policyStr = stringifyPolicy(bucket.policy?.document);
+  console.log('bucket.policy?.document: ' + policyStr);
+  expect(bucket.policy?.document).toBeDefined();
+
+  assertK9StatementsAddedToS3ResourcePolicy(addToResourcePolicyResults, k9BucketPolicyProps);
+  let policyObj = JSON.parse(policyStr);
+  let actualPolicyStatements = policyObj.Statement;
+  expect(actualPolicyStatements).toBeDefined();
+
+  assertContainsStatementWithId(SID_ALLOW_CLOUDFRONT_READ_ACCESS, actualPolicyStatements);
+
+  for (let stmt of actualPolicyStatements) {
+    if (SID_DENY_EVERYONE_ELSE == stmt.Sid) {
+      expect(stmt.Condition.StringNotEqualsIfExists['aws:PrincipalServiceName']).toEqual('cloudfront.amazonaws.com');
+      expect(stmt.Condition.ArnNotEquals['aws:PrincipalArn']).toBeTruthy();
+    }
+  }
+
+});
+
+
 test('K9BucketPolicy - IAccessSpec with set of capabilities', () => {
   const localstack = new cdk.Stack(app, 'K9BucketPolicyMultiAccessCapa');
   const bucket = new s3.Bucket(localstack, 'TestBucketWithMultiAccessSpec', {});
@@ -463,6 +504,9 @@ function assertK9StatementsAddedToS3ResourcePolicy(addToResourcePolicyResults: A
   k9BucketPolicyProps?: K9BucketPolicyProps) {
   let numExpectedStatements = 9;
   if (k9BucketPolicyProps && k9BucketPolicyProps.publicReadAccess) {
+    numExpectedStatements += 1;
+  }
+  if (k9BucketPolicyProps && k9BucketPolicyProps.allowCloudFrontOACReadAccess) {
     numExpectedStatements += 1;
   }
   if (k9BucketPolicyProps && !(k9BucketPolicyProps.enforceEncryptionAtRest ?? true)) {


### PR DESCRIPTION
(feat) Allow AWS services to access protected S3 buckets in a scalable way using a new `IAWSServiceAccessGenerator` interface.

First supported service: [CloudFront OAC](https://aws.amazon.com/blogs/networking-and-content-delivery/amazon-cloudfront-introduces-origin-access-control-oac/)

Fixes #29 