### PR TITLE
fix: several resources had admin actions in the delete-data sections

### DIFF
--- a/resources/capability_summary.json
+++ b/resources/capability_summary.json
@@ -50,9 +50,6 @@
       "cloudtrail:StopLogging",
       "cloudtrail:UpdateTrail"
     ],
-    "delete-data": [
-      "cloudtrail:DeleteTrail"
-    ],
     "read-config": [
       "cloudtrail:DescribeTrails",
       "cloudtrail:GetEventSelectors",
@@ -88,8 +85,6 @@
     ],
     "delete-data": [
       "dynamodb:DeleteItem",
-      "dynamodb:DeleteTable",
-      "dynamodb:DeleteTableReplica",
       "dynamodb:PartiQLDelete"
     ],
     "read-config": [
@@ -134,10 +129,7 @@
       "dax:UpdateSubnetGroup"
     ],
     "delete-data": [
-      "dax:DeleteCluster",
-      "dax:DeleteItem",
-      "dax:DeleteParameterGroup",
-      "dax:DeleteSubnetGroup"
+      "dax:DeleteItem"
     ],
     "read-config": [
       "dax:DescribeClusters",
@@ -483,15 +475,6 @@
       "rds:StopDBCluster",
       "rds:StopDBInstance"
     ],
-    "delete-data": [
-      "rds:DeleteDBCluster",
-      "rds:DeleteDBClusterSnapshot",
-      "rds:DeleteDBInstance",
-      "rds:DeleteDBInstanceAutomatedBackup",
-      "rds:DeleteDBSnapshot",
-      "rds:DeleteGlobalCluster",
-      "rds:DeleteOptionGroup"
-    ],
     "read-config": [
       "rds:DescribeAccountAttributes",
       "rds:DescribeCertificates",
@@ -623,9 +606,8 @@
       "redshift:RotateEncryptionKey"
     ],
     "delete-data": [
-      "redshift:BatchDeleteClusterSnapshots",
-      "redshift:DeleteCluster",
-      "redshift:DeleteClusterSnapshot"
+      "redshift:DeleteSavedQueries",
+      "redshift:DeleteScheduledAction"
     ],
     "read-config": [
       "redshift:DescribeAccountAttributes",
@@ -677,10 +659,6 @@
       "redshift:CopyClusterSnapshot",
       "redshift:CreateSavedQuery",
       "redshift:CreateScheduledAction",
-      "redshift:CreateTags",
-      "redshift:DeleteSavedQueries",
-      "redshift:DeleteScheduledAction",
-      "redshift:DeleteTags",
       "redshift:ExecuteQuery",
       "redshift:ModifySavedQuery",
       "redshift:ViewQueriesInConsole"
@@ -782,19 +760,15 @@
   "SQS": {
     "administer-resource": [
       "sqs:AddPermission",
-      "sqs:CancelMessageMoveTask",
       "sqs:CreateQueue",
       "sqs:DeleteQueue",
-      "sqs:PurgeQueue",
       "sqs:RemovePermission",
       "sqs:SetQueueAttributes",
-      "sqs:StartMessageMoveTask",
       "sqs:TagQueue",
       "sqs:UntagQueue"
     ],
     "delete-data": [
       "sqs:DeleteMessage",
-      "sqs:DeleteQueue",
       "sqs:PurgeQueue"
     ],
     "read-config": [
@@ -810,7 +784,9 @@
     ],
     "write-data": [
       "sqs:ChangeMessageVisibility",
-      "sqs:SendMessage"
+      "sqs:SendMessage",
+      "sqs:StartMessageMoveTask",
+      "sqs:CancelMessageMoveTask"
     ]
   },
   "STS": {

--- a/test/__snapshots__/k9.test.ts.snap
+++ b/test/__snapshots__/k9.test.ts.snap
@@ -133,8 +133,6 @@ exports[`DynamoDBResourcePolicy Typical usage 1`] = `
                   {
                     "Action": [
                       "dynamodb:DeleteItem",
-                      "dynamodb:DeleteTable",
-                      "dynamodb:DeleteTableReplica",
                       "dynamodb:PartiQLDelete",
                     ],
                     "Condition": {
@@ -346,8 +344,6 @@ exports[`DynamoDBResourcePolicy restrictToPrincipalOrgIDs restricts write-data t
                   {
                     "Action": [
                       "dynamodb:DeleteItem",
-                      "dynamodb:DeleteTable",
-                      "dynamodb:DeleteTableReplica",
                       "dynamodb:PartiQLDelete",
                     ],
                     "Condition": {

--- a/test/__snapshots__/sqs.test.ts.snap
+++ b/test/__snapshots__/sqs.test.ts.snap
@@ -15,31 +15,10 @@ exports[`SQSResourcePolicy Typical usage 1`] = `
             {
               "Action": [
                 "sqs:AddPermission",
-                "sqs:CancelMessageMoveTask",
                 "sqs:CreateQueue",
                 "sqs:DeleteQueue",
-                "sqs:PurgeQueue",
                 "sqs:RemovePermission",
                 "sqs:SetQueueAttributes",
-              ],
-              "Condition": {
-                "ArnEquals": {
-                  "aws:PrincipalArn": [
-                    "arn:aws:iam::139710491120:user/ci",
-                    "arn:aws:iam::139710491120:role/k9-dev-appeng",
-                  ],
-                },
-              },
-              "Effect": "Allow",
-              "Principal": {
-                "AWS": "*",
-              },
-              "Resource": "*",
-              "Sid": "Allow Restricted administer-resource 1",
-            },
-            {
-              "Action": [
-                "sqs:StartMessageMoveTask",
                 "sqs:TagQueue",
                 "sqs:UntagQueue",
               ],
@@ -56,7 +35,7 @@ exports[`SQSResourcePolicy Typical usage 1`] = `
                 "AWS": "*",
               },
               "Resource": "*",
-              "Sid": "Allow Restricted administer-resource 2",
+              "Sid": "Allow Restricted administer-resource",
             },
             {
               "Action": [
@@ -103,6 +82,8 @@ exports[`SQSResourcePolicy Typical usage 1`] = `
               "Action": [
                 "sqs:ChangeMessageVisibility",
                 "sqs:SendMessage",
+                "sqs:StartMessageMoveTask",
+                "sqs:CancelMessageMoveTask",
               ],
               "Condition": {
                 "ArnEquals": {
@@ -121,7 +102,6 @@ exports[`SQSResourcePolicy Typical usage 1`] = `
             {
               "Action": [
                 "sqs:DeleteMessage",
-                "sqs:DeleteQueue",
                 "sqs:PurgeQueue",
               ],
               "Condition": {

--- a/test/events.test.ts
+++ b/test/events.test.ts
@@ -47,7 +47,7 @@ describe('EventBusResourcePolicy', () => {
     };
 
     let addToResourcePolicyResults = k9.events.grantAccessViaResourcePolicy(eventBusResourcePolicyProps);
-    console.log('addToResourcePolicyResults: ' + addToResourcePolicyResults);
+    // console.log('addToResourcePolicyResults: ' + addToResourcePolicyResults);
 
     for (let result of addToResourcePolicyResults) {
       expect(result.statementAdded).toBeTruthy();
@@ -66,7 +66,7 @@ describe('EventBusResourcePolicy', () => {
 
     const policy = k9.events.makeResourcePolicy(eventBusResourcePolicyProps);
     let policyStr = stringifyPolicy(policy);
-    console.log('EventBridge policy: ' + policyStr);
+    // console.log('EventBridge policy: ' + policyStr);
 
     let policyObj = JSON.parse(policyStr);
     let statements = policyObj.Statement;
@@ -122,7 +122,7 @@ describe('EventBusResourcePolicy', () => {
 
     const policy = k9.events.makeResourcePolicy(eventBusResourcePolicyProps);
     let policyStr = stringifyPolicy(policy);
-    console.log('EventBridge org-scoped policy: ' + policyStr);
+    // console.log('EventBridge org-scoped policy: ' + policyStr);
 
     let policyObj = JSON.parse(policyStr);
     let statements = policyObj.Statement;
@@ -177,7 +177,7 @@ describe('EventBusResourcePolicy', () => {
 
     const policy = k9.events.makeResourcePolicy(eventBusResourcePolicyProps);
     let policyStr = stringifyPolicy(policy);
-    console.log('EventBridge specific+org policy: ' + policyStr);
+    // console.log('EventBridge specific+org policy: ' + policyStr);
 
     let policyObj = JSON.parse(policyStr);
     let statements = policyObj.Statement;
@@ -233,7 +233,7 @@ describe('EventBusResourcePolicy', () => {
 
     const policy = k9.events.makeResourcePolicy(eventBusResourcePolicyProps);
     let policyStr = stringifyPolicy(policy);
-    console.log('EventBridge multi-account+multi-org policy: ' + policyStr);
+    // console.log('EventBridge multi-account+multi-org policy: ' + policyStr);
 
     let policyObj = JSON.parse(policyStr);
     let statements = policyObj.Statement;

--- a/test/k9.test.js
+++ b/test/k9.test.js
@@ -46,7 +46,7 @@ test('K9BucketPolicy - typical usage', () => {
     let addToResourcePolicyResults = k9.s3.grantAccessViaResourcePolicy(stack, "S3Bucket", k9BucketPolicyProps);
     expect(bucket.policy).toBeDefined();
     let policyStr = helpers_1.stringifyPolicy((_a = bucket.policy) === null || _a === void 0 ? void 0 : _a.document);
-    console.log("bucket.policy?.document: " + policyStr);
+    // console.log("bucket.policy?.document: " + policyStr);
     expect((_b = bucket.policy) === null || _b === void 0 ? void 0 : _b.document).toBeDefined();
     assertK9StatementsAddedToS3ResourcePolicy(addToResourcePolicyResults);
     let policyObj = JSON.parse(policyStr);
@@ -76,7 +76,7 @@ test('K9BucketPolicy - specify encryption method - KMS', () => {
     let addToResourcePolicyResults = k9.s3.grantAccessViaResourcePolicy(stack, "BucketPolicyWithEncryptionMethodKMS", k9BucketPolicyProps);
     expect(bucket.policy).toBeDefined();
     let policyStr = helpers_1.stringifyPolicy((_a = bucket.policy) === null || _a === void 0 ? void 0 : _a.document);
-    console.log("bucket.policy?.document: " + policyStr);
+    // console.log("bucket.policy?.document: " + policyStr);
     expect((_b = bucket.policy) === null || _b === void 0 ? void 0 : _b.document).toBeDefined();
     assertK9StatementsAddedToS3ResourcePolicy(addToResourcePolicyResults);
     let policyObj = JSON.parse(policyStr);
@@ -103,7 +103,7 @@ test('K9BucketPolicy - specify encryption method - S3_MANAGED', () => {
     let addToResourcePolicyResults = k9.s3.grantAccessViaResourcePolicy(stack, "BucketPolicyWithAlternateEncryptionMethod", k9BucketPolicyProps);
     expect(bucket.policy).toBeDefined();
     let policyStr = helpers_1.stringifyPolicy((_a = bucket.policy) === null || _a === void 0 ? void 0 : _a.document);
-    console.log("bucket.policy?.document: " + policyStr);
+    // console.log("bucket.policy?.document: " + policyStr);
     expect((_b = bucket.policy) === null || _b === void 0 ? void 0 : _b.document).toBeDefined();
     assertK9StatementsAddedToS3ResourcePolicy(addToResourcePolicyResults);
     let policyObj = JSON.parse(policyStr);
@@ -133,7 +133,7 @@ test('K9BucketPolicy - for a public website (direct to S3) - sse-s3 + public-rea
     let addToResourcePolicyResults = k9.s3.grantAccessViaResourcePolicy(stack, "BucketPolicyForPublicWebsite", k9BucketPolicyProps);
     expect(bucket.policy).toBeDefined();
     let policyStr = helpers_1.stringifyPolicy((_a = bucket.policy) === null || _a === void 0 ? void 0 : _a.document);
-    console.log("bucket.policy?.document: " + policyStr);
+    // console.log("bucket.policy?.document: " + policyStr);
     expect((_b = bucket.policy) === null || _b === void 0 ? void 0 : _b.document).toBeDefined();
     assertK9StatementsAddedToS3ResourcePolicy(addToResourcePolicyResults, k9BucketPolicyProps);
     let policyObj = JSON.parse(policyStr);
@@ -173,7 +173,7 @@ test('K9BucketPolicy - AccessSpec with set of capabilities', () => {
     };
     let addToResourcePolicyResults = k9.s3.grantAccessViaResourcePolicy(localstack, "S3BucketMultiAccessSpec", k9BucketPolicyProps);
     expect(bucket.policy).toBeDefined();
-    console.log("bucket.policy?.document: " + helpers_1.stringifyPolicy((_a = bucket.policy) === null || _a === void 0 ? void 0 : _a.document));
+    // console.log("bucket.policy?.document: " + helpers_1.stringifyPolicy((_a = bucket.policy) === null || _a === void 0 ? void 0 : _a.document));
     expect((_b = bucket.policy) === null || _b === void 0 ? void 0 : _b.document).toBeDefined();
     assertK9StatementsAddedToS3ResourcePolicy(addToResourcePolicyResults);
     assert_1.expect(localstack).to(assert_1.haveResource("AWS::S3::Bucket"));
@@ -189,7 +189,7 @@ test('k9.s3.grantAccessViaResourcePolicy merges permissions for autoDeleteObject
     });
     let originalBucketPolicy = bucket.policy;
     expect(originalBucketPolicy).toBeTruthy();
-    console.log("original bucketPolicy.document: " + helpers_1.stringifyPolicy((_a = bucket === null || bucket === void 0 ? void 0 : bucket.policy) === null || _a === void 0 ? void 0 : _a.document));
+    // console.log("original bucketPolicy.document: " + helpers_1.stringifyPolicy((_a = bucket === null || bucket === void 0 ? void 0 : bucket.policy) === null || _a === void 0 ? void 0 : _a.document));
     const k9BucketPolicyProps = {
         bucket: bucket,
         k9DesiredAccess: new Array({
@@ -203,7 +203,7 @@ test('k9.s3.grantAccessViaResourcePolicy merges permissions for autoDeleteObject
     let addToResourcePolicyResults = k9.s3.grantAccessViaResourcePolicy(stack, "AutoDeleteBucket", k9BucketPolicyProps);
     expect(bucket.policy).toStrictEqual(originalBucketPolicy);
     assertK9StatementsAddedToS3ResourcePolicy(addToResourcePolicyResults);
-    console.log("k9 bucket policy: " + helpers_1.stringifyPolicy((_b = bucket.policy) === null || _b === void 0 ? void 0 : _b.document));
+    // console.log("k9 bucket policy: " + helpers_1.stringifyPolicy((_b = bucket.policy) === null || _b === void 0 ? void 0 : _b.document));
     expect(assert_1.SynthUtils.toCloudFormation(stack)).toMatchSnapshot();
 });
 describe('K9KeyPolicy', () => {
@@ -231,7 +231,7 @@ describe('K9KeyPolicy', () => {
         expect(k9KeyPolicyProps.trustAccountIdentities).toBeFalsy();
         const keyPolicy = k9.kms.makeKeyPolicy(k9KeyPolicyProps);
         let policyJsonStr = helpers_1.stringifyPolicy(keyPolicy);
-        console.log(`keyPolicy.document (trustAccountIdentities: ${k9KeyPolicyProps.trustAccountIdentities}): ${policyJsonStr}`);
+        // console.log(`keyPolicy.document (trustAccountIdentities: ${k9KeyPolicyProps.trustAccountIdentities}): ${policyJsonStr}`);
         let policyObj = JSON.parse(policyJsonStr);
         let actualPolicyStatements = policyObj['Statement'];
         expect(actualPolicyStatements).toBeDefined();
@@ -260,7 +260,7 @@ describe('K9KeyPolicy', () => {
         expect(k9KeyPolicyProps.trustAccountIdentities).toBeTruthy();
         const keyPolicy = k9.kms.makeKeyPolicy(k9KeyPolicyProps);
         let policyJsonStr = helpers_1.stringifyPolicy(keyPolicy);
-        console.log(`keyPolicy.document (trustAccountIdentities: ${k9KeyPolicyProps.trustAccountIdentities}): ${policyJsonStr}`);
+        // console.log(`keyPolicy.document (trustAccountIdentities: ${k9KeyPolicyProps.trustAccountIdentities}): ${policyJsonStr}`);
         let policyObj = JSON.parse(policyJsonStr);
         let actualPolicyStatements = policyObj['Statement'];
         expect(actualPolicyStatements).toBeDefined();
@@ -305,7 +305,7 @@ describe('K9KeyPolicy', () => {
 });
 function assertContainsStatementWithId(expectStmtId, statements) {
     let foundStmt = false;
-    console.log(`looking for statement id: ${expectStmtId}`);
+    // console.log(`looking for statement id: ${expectStmtId}`);
     for (let stmt of statements) {
         if (expectStmtId == stmt.Sid) {
             foundStmt = true;

--- a/test/k9.test.ts
+++ b/test/k9.test.ts
@@ -69,7 +69,7 @@ test('K9BucketPolicy - typical usage', () => {
   expect(bucket.policy).toBeDefined();
 
   let policyStr = stringifyPolicy(bucket.policy?.document);
-  console.log('bucket.policy?.document: ' + policyStr);
+  // console.log('bucket.policy?.document: ' + policyStr);
   expect(bucket.policy?.document).toBeDefined();
 
   assertK9StatementsAddedToS3ResourcePolicy(addToResourcePolicyResults);
@@ -119,7 +119,7 @@ test('K9BucketPolicy - do not enforce KMS encryption at rest when configured off
   expect(bucket.policy).toBeDefined();
 
   let policyStr = stringifyPolicy(bucket.policy?.document);
-  console.log('bucket.policy?.document: ' + policyStr);
+  // console.log('bucket.policy?.document: ' + policyStr);
   expect(bucket.policy?.document).toBeDefined();
 
   assertK9StatementsAddedToS3ResourcePolicy(addToResourcePolicyResults, k9BucketPolicyProps);
@@ -159,7 +159,7 @@ test('K9BucketPolicy - specify encryption method - KMS', () => {
   expect(bucket.policy).toBeDefined();
 
   let policyStr = stringifyPolicy(bucket.policy?.document);
-  console.log('bucket.policy?.document: ' + policyStr);
+  // console.log('bucket.policy?.document: ' + policyStr);
   expect(bucket.policy?.document).toBeDefined();
 
   assertK9StatementsAddedToS3ResourcePolicy(addToResourcePolicyResults);
@@ -193,7 +193,7 @@ test('K9BucketPolicy - specify encryption method - S3_MANAGED', () => {
   expect(bucket.policy).toBeDefined();
 
   let policyStr = stringifyPolicy(bucket.policy?.document);
-  console.log('bucket.policy?.document: ' + policyStr);
+  // console.log('bucket.policy?.document: ' + policyStr);
   expect(bucket.policy?.document).toBeDefined();
 
   assertK9StatementsAddedToS3ResourcePolicy(addToResourcePolicyResults);
@@ -231,7 +231,7 @@ test('K9BucketPolicy - for a public website (direct to S3) - sse-s3 + public-rea
   expect(bucket.policy).toBeDefined();
 
   let policyStr = stringifyPolicy(bucket.policy?.document);
-  console.log('bucket.policy?.document: ' + policyStr);
+  // console.log('bucket.policy?.document: ' + policyStr);
   expect(bucket.policy?.document).toBeDefined();
 
   assertK9StatementsAddedToS3ResourcePolicy(addToResourcePolicyResults, k9BucketPolicyProps);
@@ -272,15 +272,15 @@ test('K9BucketPolicy - allow CloudFront OAC', () => {
     ),
   };
 
-  let addToResourcePolicyResults = k9.s3.grantAccessViaResourcePolicy(stack, 'K9BucketPolicyCloudFrontOAC', k9BucketPolicyProps);
+  k9.s3.grantAccessViaResourcePolicy(stack, 'K9BucketPolicyCloudFrontOAC', k9BucketPolicyProps);
   expect(bucket.policy).toBeDefined();
 
   let policyStr = stringifyPolicy(bucket.policy?.document);
-  console.log('bucket.policy?.document: ' + policyStr);
+  // console.log('bucket.policy?.document: ' + policyStr);
   expect(bucket.policy?.document).toBeDefined();
 
   // assertK9StatementsAddedToS3ResourcePolicy(addToResourcePolicyResults, k9BucketPolicyProps);
-  console.log('addToResourcePolicyResults: '+ addToResourcePolicyResults);
+  // console.log('addToResourcePolicyResults: '+ addToResourcePolicyResults);
   let policyObj = JSON.parse(policyStr);
   let actualPolicyStatements = policyObj.Statement;
   expect(actualPolicyStatements).toBeDefined();
@@ -327,7 +327,7 @@ test('K9BucketPolicy - IAccessSpec with set of capabilities', () => {
   let addToResourcePolicyResults = k9.s3.grantAccessViaResourcePolicy(localstack, 'S3BucketMultiAccessSpec', k9BucketPolicyProps);
   expect(bucket.policy).toBeDefined();
 
-  console.log('bucket.policy?.document: ' + stringifyPolicy(bucket.policy?.document));
+  // console.log('bucket.policy?.document: ' + stringifyPolicy(bucket.policy?.document));
   expect(bucket.policy?.document).toBeDefined();
 
   assertK9StatementsAddedToS3ResourcePolicy(addToResourcePolicyResults);
@@ -346,7 +346,7 @@ test('k9.s3.grantAccessViaResourcePolicy merges permissions for autoDeleteObject
 
   let originalBucketPolicy = bucket.policy;
   expect(originalBucketPolicy).toBeTruthy();
-  console.log('original bucketPolicy.document: ' + stringifyPolicy(bucket?.policy?.document));
+  // console.log('original bucketPolicy.document: ' + stringifyPolicy(bucket?.policy?.document));
 
   const k9BucketPolicyProps: K9BucketPolicyProps = {
     bucket: bucket,
@@ -367,7 +367,7 @@ test('k9.s3.grantAccessViaResourcePolicy merges permissions for autoDeleteObject
 
   assertK9StatementsAddedToS3ResourcePolicy(addToResourcePolicyResults);
 
-  console.log('k9 bucket policy: ' + stringifyPolicy(bucket.policy?.document));
+  // console.log('k9 bucket policy: ' + stringifyPolicy(bucket.policy?.document));
   expect(SynthUtils.toCloudFormation(stack)).toMatchSnapshot();
 });
 
@@ -404,7 +404,7 @@ test('K9BucketPolicy - restrictToPrincipalOrgIDs restricts write-data to org', (
   }
 
   let policyStr = stringifyPolicy(bucket.policy?.document);
-  console.log('org-restricted bucket policy: ' + policyStr);
+  // console.log('org-restricted bucket policy: ' + policyStr);
   let policyObj = JSON.parse(policyStr);
   let statements = policyObj.Statement;
 
@@ -471,7 +471,7 @@ describe('K9KeyPolicy', () => {
     const keyPolicy = k9.kms.makeKeyPolicy(k9KeyPolicyProps);
 
     let policyJsonStr = stringifyPolicy(keyPolicy);
-    console.log(`keyPolicy.document (trustAccountIdentities: ${k9KeyPolicyProps.trustAccountIdentities}): ${policyJsonStr}`);
+    // console.log(`keyPolicy.document (trustAccountIdentities: ${k9KeyPolicyProps.trustAccountIdentities}): ${policyJsonStr}`);
     let policyObj = JSON.parse(policyJsonStr);
 
     let actualPolicyStatements = policyObj.Statement;
@@ -507,7 +507,7 @@ describe('K9KeyPolicy', () => {
     const keyPolicy = k9.kms.makeKeyPolicy(k9KeyPolicyProps);
 
     let policyJsonStr = stringifyPolicy(keyPolicy);
-    console.log(`keyPolicy.document (trustAccountIdentities: ${k9KeyPolicyProps.trustAccountIdentities}): ${policyJsonStr}`);
+    // console.log(`keyPolicy.document (trustAccountIdentities: ${k9KeyPolicyProps.trustAccountIdentities}): ${policyJsonStr}`);
     let policyObj = JSON.parse(policyJsonStr);
 
     let actualPolicyStatements = policyObj.Statement;
@@ -577,7 +577,7 @@ describe('K9KeyPolicy', () => {
     const keyPolicy = k9.kms.makeKeyPolicy(k9KeyPolicyProps);
 
     let policyJsonStr = stringifyPolicy(keyPolicy);
-    console.log(`keyPolicy.document (trustAccountIdentities: ${k9KeyPolicyProps.trustAccountIdentities}): ${policyJsonStr}`);
+    // console.log(`keyPolicy.document (trustAccountIdentities: ${k9KeyPolicyProps.trustAccountIdentities}): ${policyJsonStr}`);
     let policyObj = JSON.parse(policyJsonStr);
 
     let actualPolicyStatements = policyObj.Statement;
@@ -632,7 +632,7 @@ describe('K9KeyPolicy', () => {
     const keyPolicy = k9.kms.makeKeyPolicy(k9KeyPolicyProps);
 
     let policyJsonStr = stringifyPolicy(keyPolicy);
-    console.log('org-restricted key policy: ' + policyJsonStr);
+    // console.log('org-restricted key policy: ' + policyJsonStr);
     let policyObj = JSON.parse(policyJsonStr);
     let statements = policyObj.Statement;
     expect(statements).toBeDefined();
@@ -704,7 +704,7 @@ describe('DynamoDBResourcePolicy', () => {
     };
 
     let resourcePolicy = k9.dynamodb.makeResourcePolicy(ddbResourcePolicyProps);
-    console.log('resourcePolicy: ' + stringifyPolicy(resourcePolicy));
+    // console.log('resourcePolicy: ' + stringifyPolicy(resourcePolicy));
 
     expect(resourcePolicy).toBeDefined();
 
@@ -735,14 +735,14 @@ describe('DynamoDBResourcePolicy', () => {
       expect(policyStatementMap[expectStmtId]).toBeTruthy();
     }
 
-    const table = new dynamodb.TableV2(stack, 'test-table-typical-usage', {
+    new dynamodb.TableV2(stack, 'test-table-typical-usage', {
       partitionKey: { name: 'pk', type: dynamodb.AttributeType.STRING },
       removalPolicy: cdk.RemovalPolicy.DESTROY,
       resourcePolicy: resourcePolicy,
     });
 
-    console.log('table: ' + table);
-    console.log('table.resourcePolicy: ' + stringifyPolicy(table.resourcePolicy));
+    // console.log('table: ' + table);
+    // console.log('table.resourcePolicy: ' + stringifyPolicy(table.resourcePolicy));
 
     expectCDK(stack).to(haveResource('AWS::DynamoDB::GlobalTable'));
     expect(SynthUtils.toCloudFormation(stack)).toMatchSnapshot();
@@ -778,7 +778,7 @@ describe('DynamoDBResourcePolicy', () => {
 
     let resourcePolicy = k9.dynamodb.makeResourcePolicy(ddbResourcePolicyProps);
     let policyStr = stringifyPolicy(resourcePolicy);
-    console.log('org-restricted DynamoDB policy: ' + policyStr);
+    // console.log('org-restricted DynamoDB policy: ' + policyStr);
 
     let policyObj = JSON.parse(policyStr);
     let statements = policyObj.Statement;
@@ -813,13 +813,13 @@ describe('DynamoDBResourcePolicy', () => {
     expect(denyUntrustedOrgsStmt.Effect).toEqual('Deny');
     expect(denyUntrustedOrgsStmt.Condition.StringNotEquals['aws:PrincipalOrgID']).toEqual(['o-abc123']);
 
-    const table = new dynamodb.TableV2(stack, 'test-table-org-restricted', {
+    new dynamodb.TableV2(stack, 'test-table-org-restricted', {
       partitionKey: { name: 'pk', type: dynamodb.AttributeType.STRING },
       removalPolicy: cdk.RemovalPolicy.DESTROY,
       resourcePolicy: resourcePolicy,
     });
 
-    console.log('table: ' + table);
+    // console.log('table: ' + table);
     expectCDK(stack).to(haveResource('AWS::DynamoDB::GlobalTable'));
     expect(SynthUtils.toCloudFormation(stack)).toMatchSnapshot();
   });
@@ -829,7 +829,7 @@ describe('DynamoDBResourcePolicy', () => {
 
 function assertContainsStatementWithId(expectStmtId:string, statements:any) {
   let foundStmt = false;
-  console.log(`looking for statement id: ${expectStmtId}`);
+  // console.log(`looking for statement id: ${expectStmtId}`);
   for (let stmt of statements) {
     if (expectStmtId == stmt.Sid) {
       foundStmt = true;

--- a/test/k9policy.test.js
+++ b/test/k9policy.test.js
@@ -43,7 +43,7 @@ test('K9PolicyFactory#getAllowedPrincipalArns', () => {
 // noinspection JSUnusedLocalSymbols
 function logStatement(stmt) {
     let statementJsonStr = helpers_1.stringifyStatement(stmt);
-    console.log(`actual policy statement: ${stmt} json: ${statementJsonStr}`);
+    // console.log(`actual policy statement: ${stmt} json: ${statementJsonStr}`);
 }
 describe('K9PolicyFactory#makeAllowStatements', () => {
     const k9PolicyFactory = new k9policy_1.K9PolicyFactory();

--- a/test/k9policy.test.ts
+++ b/test/k9policy.test.ts
@@ -1,4 +1,4 @@
-import { AnyPrincipal, PolicyStatement } from 'aws-cdk-lib/aws-iam';
+import { AnyPrincipal } from 'aws-cdk-lib/aws-iam';
 import { stringifyStatement } from './helpers';
 import {
   AccessCapability,
@@ -155,10 +155,10 @@ test('K9PolicyFactory#getAllowedPrincipalArns', () => {
 
 // noinspection JSUnusedLocalSymbols
 // @ts-ignore
-function logStatement(stmt: PolicyStatement) {
-  let statementJsonStr = stringifyStatement(stmt);
-  console.log(`actual policy statement: ${stmt} json: ${statementJsonStr}`);
-}
+// function logStatement(stmt: PolicyStatement) {
+//   let statementJsonStr = stringifyStatement(stmt);
+//   console.log(`actual policy statement: ${stmt} json: ${statementJsonStr}`);
+// }
 
 describe('K9PolicyFactory#makeAllowStatements', () => {
   const k9PolicyFactory = new K9PolicyFactory();

--- a/test/sqs.test.ts
+++ b/test/sqs.test.ts
@@ -63,13 +63,13 @@ describe('SQSResourcePolicy', () => {
     };
 
     let addToResourcePolicyResults = k9.sqs.grantAccessViaResourcePolicy(sqsResourcePolicyProps);
-    console.log('addToResourcePolicyResults: ' + addToResourcePolicyResults);
+    // console.log('addToResourcePolicyResults: ' + addToResourcePolicyResults);
 
     for (let result of addToResourcePolicyResults) {
       expect(result.statementAdded).toBeTruthy();
     }
 
-    console.log('queue: ' + queue);
+    // console.log('queue: ' + queue);
 
     // sadly, fails with Resolution error: statement.freeze is not a function deep in CDK
     expectCDK(stack).to(haveResource('AWS::SQS::Queue'));
@@ -87,7 +87,7 @@ describe('SQSResourcePolicy', () => {
     };
 
     let resourcePolicy = k9.sqs.makeResourcePolicy(sqsResourcePolicyProps);
-    console.log('resourcePolicy: ' + stringifyPolicy(resourcePolicy));
+    // console.log('resourcePolicy: ' + stringifyPolicy(resourcePolicy));
 
     expect(resourcePolicy).toBeDefined();
 
@@ -99,8 +99,7 @@ describe('SQSResourcePolicy', () => {
 
     const expectStmtIds = [
       SID_DENY_EVERYONE_ELSE,
-      'Allow Restricted administer-resource 1',
-      'Allow Restricted administer-resource 2',
+      'Allow Restricted administer-resource',
       'Allow Restricted read-config',
       'Allow Restricted read-data',
       'Allow Restricted write-data',
@@ -124,7 +123,7 @@ describe('SQSResourcePolicy', () => {
       queue.addToResourcePolicy(stmt);
     }
 
-    console.log('queue: ' + queue);
+    // console.log('queue: ' + queue);
   });
 
   test('restrictToPrincipalOrgIDs restricts write-data to org', () => {
@@ -159,7 +158,7 @@ describe('SQSResourcePolicy', () => {
 
     let resourcePolicy = k9.sqs.makeResourcePolicy(sqsResourcePolicyProps);
     let policyStr = stringifyPolicy(resourcePolicy);
-    console.log('org-restricted SQS policy: ' + policyStr);
+    // console.log('org-restricted SQS policy: ' + policyStr);
 
     let policyObj = JSON.parse(policyStr);
     let statements = policyObj.Statement;
@@ -172,7 +171,7 @@ describe('SQSResourcePolicy', () => {
     expect(writeStmt.Condition.StringEquals['aws:PrincipalOrgID']).toEqual(['o-abc123']);
 
     // Verify administer-resource does NOT have org constraint
-    let adminStmt1 = statements.find((s: any) => s.Sid === 'Allow Restricted administer-resource 1');
+    let adminStmt1 = statements.find((s: any) => s.Sid === 'Allow Restricted administer-resource');
     expect(adminStmt1).toBeDefined();
     expect(adminStmt1.Condition.ArnEquals).toBeDefined();
     expect(adminStmt1.Condition.StringEquals).toBeUndefined();


### PR DESCRIPTION
The read/write/delete groups are meant to operate on data and the admin is meant to operate on the resource. I found some instances where that line was blurred incorrectly. 